### PR TITLE
Add `rhel-domainname.service` to container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN yum install -y ipa-client dbus-python perl 'perl(Data::Dumper)' 'perl(Time::
 
 ADD dbus.service /etc/systemd/system/dbus.service
 RUN ln -sf dbus.service /etc/systemd/system/messagebus.service
+ADD rhel-domainname.service /etc/systemd/system/rhel-domainname.service
 
 ADD systemctl /usr/bin/systemctl
 ADD ipa-client-configure-first /usr/sbin/ipa-client-configure-first

--- a/rhel-domainname.service
+++ b/rhel-domainname.service
@@ -1,0 +1,4 @@
+[Service]
+ExecStart=/bin/true
+Type=oneshot
+RemainAfterExit=yes


### PR DESCRIPTION
This fixes a bug in the `centos-7-client` branch (the stub `rhel-domainname.service` file was copied from [here][2]).  Commit log pasted below.

Are these client branches still being maintained?  They aren't being built in the Docker hub [automated builds][1], and it looks like the server Dockerfiles have moved to the `master` branch, so I'm guessing that the client is either moving somewhere or abandoned.

Thanks for this useful project.

[1]: https://hub.docker.com/r/adelton/freeipa-server/tags/
[2]: https://github.com/fedora-cloud/Fedora-Dockerfiles/blob/master/sssd/rhel-domainname.service

-----
Fix error running `ipa-client-install`, where
`rhel-domainname.service` doesn't exist:

```
Traceback (most recent call last):
  File "/usr/sbin/ipa-client-install", line 3102, in <module>
    sys.exit(main())
  File "/usr/sbin/ipa-client-install", line 3083, in main
    rval = install(options, env, fstore, statestore)
  File "/usr/sbin/ipa-client-install", line 3043, in install
    configure_nisdomain(options=options, domain=cli_domain)
  File "/usr/sbin/ipa-client-install", line 1508, in configure_nisdomain
    services.knownservices.domainname.restart()
  File "/usr/lib/python2.7/site-packages/ipaplatform/base/services.py", line 314, in restart
    capture_output=capture_output)
  File "/usr/lib/python2.7/site-packages/ipapython/ipautil.py", line 373, in run
    raise CalledProcessError(p.returncode, arg_string, stdout)
subprocess.CalledProcessError: Command ''/bin/systemctl' 'restart' 'rhel-domainname.service'' returned non-zero exit status 2
```