### PR TITLE
Fix 14: support the --external-ca workflow.

### DIFF
--- a/ipa-server-configure-first
+++ b/ipa-server-configure-first
@@ -178,6 +178,9 @@ else
 		grep -v '/$' /etc/volume-data-list | sed 's!^!.!' | xargs touch
 	)
 
+	# Workaround 1409806
+	rmdir /data/etc/pki/pki-tomcat 2> /dev/null || :
+
 	while read i ; do
 		rm -f "$i"
 		if [ -e "/data$i" ] ; then

--- a/ipa-server-configure-first
+++ b/ipa-server-configure-first
@@ -208,6 +208,14 @@ else
 			fi
 		done
 		cp /etc/volume-version /data/volume-version
+
+		if ! [ -f /etc/ipa/ca.crt ] && [ -f /root/ipa.csr ] ; then
+			cp -p /root/ipa.csr /data/ipa.csr
+			echo "FreeIPA CA CSR stored in file ipa.csr located in bind-mounted data volume."
+			touch /run/ipa/exit-on-finished
+			exit
+		fi
+
 		if systemctl is-active -q named-pkcs11 || [ -f /run/ipa/ipa-server-ip ] ; then
 			cp -f /etc/resolv.conf /data/etc/resolv.conf.ipa
 			while ! host -t A $HOSTNAME > /dev/null ; do

--- a/ipa-server-configure-first
+++ b/ipa-server-configure-first
@@ -177,7 +177,13 @@ else
 		grep -v '/$' /etc/volume-data-list | xargs dirname | sed 's!^!.!' | xargs mkdir -p
 		grep -v '/$' /etc/volume-data-list | sed 's!^!.!' | xargs touch
 	)
-	xargs rm -f < /etc/volume-data-mv-list
+
+	while read i ; do
+		rm -f "$i"
+		if [ -e "/data$i" ] ; then
+			( cd /data && tar cf - ".$i" ) | tar xf -
+		fi
+	done < /etc/volume-data-mv-list
 
 	HOSTNAME_SHORT=${HOSTNAME%%.*}
 	DOMAIN=${HOSTNAME#*.}

--- a/ipa-server-configure-first
+++ b/ipa-server-configure-first
@@ -175,7 +175,6 @@ else
 		cd /data
 		grep '/$' /etc/volume-data-list | sed 's!^!.!' | xargs mkdir -p
 		grep -v '/$' /etc/volume-data-list | xargs dirname | sed 's!^!.!' | xargs mkdir -p
-		grep -v '/$' /etc/volume-data-list | sed 's!^!.!' | xargs touch
 	)
 
 	# Workaround 1409806

--- a/ipa-server-configure-first
+++ b/ipa-server-configure-first
@@ -194,6 +194,11 @@ else
 		usage "The container has to have fully-qualified hostname defined."
 	fi
 
+	# Workaround 1409786
+	if grep -q -- --external.cert.file $( for i in /run/ipa /data ; do test -e $i/$COMMAND-options && echo $_ ; done ) ; then
+		/usr/sbin/ipactl --force start || :
+	fi
+
 	STDIN=/dev/stdin
 	STDOUT=/dev/stdout
 	STDERR=/dev/stderr

--- a/ipa-server-configure-first
+++ b/ipa-server-configure-first
@@ -217,8 +217,8 @@ else
 			rm -rf /data$i
 			if [ -e $i ] ; then
 				mv $i /data$i
-				ln -sf /data$i $i
 			fi
+			ln -sf /data$i $i
 		done
 		cp /etc/volume-version /data/volume-version
 


### PR DESCRIPTION
With the current code, that two-phase --external-ca / --external-cert-file workflow was not supported well. With this set of patches, first time the container is run with --external-ca, ipa.csr is stored in the /data volume. The second time the container is run with --external-cert-file parameters pointing to the external CA certificate and the new IPA server certificate, it will continue with the configuration of the outstanding components, including the DNS server that https://github.com/freeipa/freeipa-container/issues/14 reports failing.