### PR TITLE
Introduce a Dockerfile using Fedora 25 nightly builds of FreeIPA master

### DIFF
--- a/Dockerfile.fedora-25-master-nightly
+++ b/Dockerfile.fedora-25-master-nightly
@@ -1,0 +1,87 @@
+# Clone from the Fedora 25 image
+FROM fedora:25
+
+MAINTAINER FreeIPA Developers <freeipa-devel@redhat.com>
+
+RUN mkdir -p /run/lock \
+    && cd /etc/yum.repos.d \
+    && curl -O https://copr.fedorainfracloud.org/coprs/g/freeipa/freeipa-master/repo/fedora-25/group_freeipa-freeipa-master-fedora-25.repo \
+    && curl -O https://copr.fedorainfracloud.org/coprs/g/freeipa/freeipa-master-nightly/repo/fedora-25/group_freeipa-freeipa-master-nightly-fedora-25.repo \
+    && dnf install -y freeipa-server \
+    freeipa-server-dns \
+    freeipa-server-trust-ad \
+    initscripts \
+    --best --allowerasing \
+    && dnf clean all
+
+# Workaround 1364139
+RUN sed -i '/installutils.verify_fqdn(config.master_host_name, options.no_host_dns)/s/)/, local_hostname=False)/' /usr/lib/python2.7/site-packages/ipaserver/install/server/replicainstall.py && python -m compileall /usr/lib/python2.7/site-packages/ipaserver/install/server/replicainstall.py
+# Workaround 1377973
+RUN sed -i 's/ips.append(ipautil.CheckedIPAddress(ha, match_local=True))/ips.append(ipautil.CheckedIPAddress(ha, match_local=False))/' /usr/lib/python2.7/site-packages/ipaserver/install/installutils.py && python -m compileall /usr/lib/python2.7/site-packages/ipaserver/install/installutils.py
+# Workaround https://fedorahosted.org/freeipa/ticket/6518
+RUN sed -i 's/getaddrinfo(fqdn/getaddrinfo(fqdn.rstrip(".")/' /usr/lib/python2.7/site-packages/ipaserver/install/installutils.py && python -m compileall /usr/lib/python2.7/site-packages/ipaserver/install/installutils.py
+# Workaround https://fedorahosted.org/spin-kickstarts/ticket/60
+RUN [ -L /etc/systemd/system/syslog.service ] && ! [ -f /etc/systemd/system/syslog.service ] && rm -f /etc/systemd/system/syslog.service
+
+RUN echo 'd0a98590c74bfe36af0ce006f7b25fa60246aecb /etc/tmpfiles.d/opendnssec.conf' | sha1sum --quiet -c && mv -v /etc/tmpfiles.d/opendnssec.conf /usr/lib/tmpfiles.d/opendnssec.conf
+RUN echo '5a70f1f3db0608c156d5b6629d4cbc3b304fc045 /etc/systemd/system/sssd.service.d/journal.conf' | sha1sum --quiet -c && rm -vf /etc/systemd/system/sssd.service.d/journal.conf
+RUN find /etc/systemd/system/* '!' -name '*.wants' | xargs rm -rvf
+RUN for i in basic.target network.service netconsole.service ; do rm -f /usr/lib/systemd/system/$i && ln -s /dev/null /usr/lib/systemd/system/$i ; done
+RUN rm -fv /usr/lib/systemd/system/sysinit.target.wants/*
+RUN echo 'disable *' > /usr/lib/systemd/system-preset/10-container-disable.preset
+
+RUN echo LANG=C > /etc/locale.conf
+
+RUN /sbin/ldconfig -X
+
+COPY init-data /usr/local/sbin/init
+COPY ipa-server-configure-first ipa-server-status-check exit-with-status ipa-volume-upgrade-* /usr/sbin/
+COPY install.sh uninstall.sh /bin/
+RUN mv /bin/hostnamectl /bin/hostnamectl.orig
+RUN mv /usr/bin/domainname /usr/bin/domainname.orig
+ADD hostnamectl-wrapper /bin/hostnamectl
+ADD hostnamectl-wrapper /usr/bin/domainname
+RUN chmod -v +x /usr/local/sbin/init /usr/sbin/ipa-server-configure-first /usr/sbin/ipa-server-status-check /usr/sbin/exit-with-status /usr/sbin/ipa-volume-upgrade-* /bin/install.sh /bin/uninstall.sh /bin/hostnamectl /usr/bin/domainname
+COPY container-ipa.target ipa-server-configure-first.service ipa-server-upgrade.service ipa-server-update-self-ip-address.service /usr/lib/systemd/system/
+RUN rmdir -v /etc/systemd/system/multi-user.target.wants \
+	&& mkdir /etc/systemd/system/container-ipa.target.wants \
+	&& ln -s /etc/systemd/system/container-ipa.target.wants /etc/systemd/system/multi-user.target.wants
+
+RUN systemctl set-default container-ipa.target
+RUN systemctl enable ipa-server-configure-first.service
+
+COPY exit-via-chroot.conf /usr/lib/systemd/system/systemd-poweroff.service.d/
+
+RUN groupadd -g 288 kdcproxy ; useradd -u 288 -g 288 -c 'IPA KDC Proxy User' -d '/var/lib/kdcproxy' -s '/sbin/nologin' kdcproxy
+
+COPY atomic-install-help /usr/share/ipa/
+COPY volume-data-list volume-data-mv-list volume-data-autoupdate /etc/
+RUN set -e ; cd / ; mkdir /data-template ; cat /etc/volume-data-list | while read i ; do echo $i ; if [ -e $i ] ; then tar cf - .$i | ( cd /data-template && tar xf - ) ; else mkdir -p /data-template$( dirname $i ) ; fi ; mkdir -p $( dirname $i ) ; if [ "$i" == /var/log/ ] ; then mv /var/log /var/log-removed ; else rm -rf $i ; fi ; ln -sf /data${i%/} ${i%/} ; done
+RUN rm -rf /var/log-removed
+RUN sed -i 's!^d /var/log.*!L /var/log - - - - /data/var/log!' /usr/lib/tmpfiles.d/var.conf
+# Workaround 1286602
+RUN mv /usr/lib/tmpfiles.d/journal-nocow.conf /usr/lib/tmpfiles.d/journal-nocow.conf.disabled
+RUN mv /data-template/etc/dirsrv/schema /usr/share/dirsrv/schema && ln -s /usr/share/dirsrv/schema /data-template/etc/dirsrv/schema
+RUN rm -f /data-template/var/lib/systemd/random-seed
+RUN echo 1.1 > /etc/volume-version
+
+ENV container docker
+
+EXPOSE 53/udp 53 80 443 389 636 88 464 88/udp 464/udp 123/udp 7389 9443 9444 9445
+
+VOLUME [ "/tmp", "/run", "/data", "/var/log/journal" ]
+
+STOPSIGNAL RTMIN+3
+ENTRYPOINT [ "/usr/local/sbin/init" ]
+RUN uuidgen > /data-template/build-id
+
+# Invocation:
+# docker run -ti -v /sys/fs/cgroup:/sys/fs/cgroup:ro --tmpfs /run --tmpfs /tmp -v /opt/ipa-data:/data:Z -h ipa.example.test ${NAME} [ options ]
+
+# For atomic, we run INSTALL --privileged but install.sh will start another unprivileged container.
+# We do it this way to be able to set hostname for the unprivileged container.
+LABEL install 'docker run -ti --rm --privileged -v /:/host -e HOST=/host -e DATADIR=/var/lib/${NAME} -e NAME=${NAME} -e IMAGE=${IMAGE} ${IMAGE} /bin/install.sh'
+LABEL run 'docker run ${RUN_OPTS} --name ${NAME} -v /var/lib/${NAME}:/data:Z -v /sys/fs/cgroup:/sys/fs/cgroup:ro --tmpfs /run --tmpfs /tmp -v /dev/urandom:/dev/random:ro ${IMAGE}'
+LABEL RUN_OPTS_FILE '/var/lib/${NAME}/docker-run-opts'
+LABEL stop 'docker stop ${NAME}'
+LABEL uninstall 'docker run --rm --privileged -v /:/host -e HOST=/host -e DATADIR=/var/lib/${NAME} ${IMAGE} /bin/uninstall.sh'


### PR DESCRIPTION
This Dockerfile is required for the early testing of the influence of
the current devel snapshots of FreeIPA on the stability of the container
image.

The images build from this Dockerfile should not be pushed to registry.
Since it contains development snapshots you need to rebuild it often
anyway.