### PR TITLE
mask proc-fs-nfsd.mount requirement of gssproxy in nightly image

### DIFF
--- a/Dockerfile.fedora-25-master-nightly
+++ b/Dockerfile.fedora-25-master-nightly
@@ -29,6 +29,8 @@ RUN find /etc/systemd/system/* '!' -name '*.wants' | xargs rm -rvf
 RUN for i in basic.target network.service netconsole.service ; do rm -f /usr/lib/systemd/system/$i && ln -s /dev/null /usr/lib/systemd/system/$i ; done
 RUN rm -fv /usr/lib/systemd/system/sysinit.target.wants/*
 RUN echo 'disable *' > /usr/lib/systemd/system-preset/10-container-disable.preset
+# Workaround https://bugzilla.redhat.com/show_bug.cgi?id=1433050
+RUN sed -i -E 's/(Requires=proc-fs-nfsd.mount)/#\1/'  /usr/lib/systemd/system/gssproxy.service
 
 RUN echo LANG=C > /etc/locale.conf
 


### PR DESCRIPTION
gssproxy requires 'proc-fs-nfsd.mount' target to be enabled in order to
run, which is possible only in privileged containers. To unblock Freeipa
4.5.x installation we have to mask this requirement.