### PR TITLE
Move user/group creation before RPM install and create ipaapi user/group

### DIFF
--- a/Dockerfile.fedora-25-master-nightly
+++ b/Dockerfile.fedora-25-master-nightly
@@ -3,6 +3,8 @@ FROM fedora:25
 
 MAINTAINER FreeIPA Developers <freeipa-devel@redhat.com>
 
+RUN groupadd -g 288 kdcproxy ; useradd -u 288 -g 288 -c 'IPA KDC Proxy User' -d '/var/lib/kdcproxy' -s '/sbin/nologin' kdcproxy
+
 RUN mkdir -p /run/lock \
     && cd /etc/yum.repos.d \
     && curl -O https://copr.fedorainfracloud.org/coprs/g/freeipa/freeipa-master/repo/fedora-25/group_freeipa-freeipa-master-fedora-25.repo \
@@ -53,8 +55,6 @@ RUN systemctl set-default container-ipa.target
 RUN systemctl enable ipa-server-configure-first.service
 
 COPY exit-via-chroot.conf /usr/lib/systemd/system/systemd-poweroff.service.d/
-
-RUN groupadd -g 288 kdcproxy ; useradd -u 288 -g 288 -c 'IPA KDC Proxy User' -d '/var/lib/kdcproxy' -s '/sbin/nologin' kdcproxy
 
 COPY atomic-install-help /usr/share/ipa/
 COPY volume-data-list volume-data-mv-list volume-data-autoupdate /etc/

--- a/Dockerfile.fedora-25-master-nightly
+++ b/Dockerfile.fedora-25-master-nightly
@@ -4,6 +4,7 @@ FROM fedora:25
 MAINTAINER FreeIPA Developers <freeipa-devel@redhat.com>
 
 RUN groupadd -g 288 kdcproxy ; useradd -u 288 -g 288 -c 'IPA KDC Proxy User' -d '/var/lib/kdcproxy' -s '/sbin/nologin' kdcproxy
+RUN groupadd -g 289 ipaapi; useradd -u 289 -g 289 -c 'IPA Framework User' -d / -s '/sbin/nologin' ipaapi
 
 RUN mkdir -p /run/lock \
     && cd /etc/yum.repos.d \


### PR DESCRIPTION
This unblocks F25 nightly image build which was broken by recent changes in the
system user creation.

https://github.com/freeipa/freeipa-container/issues/126