### PR TITLE
Add gssproxy configuration to volume data list

### DIFF
--- a/volume-data-list
+++ b/volume-data-list
@@ -1,5 +1,6 @@
 /etc/certmonger/
 /etc/dirsrv/
+/etc/gssproxy/
 /etc/httpd/alias/
 /etc/httpd/conf/
 /etc/httpd/conf.d/


### PR DESCRIPTION
This is to preserve the drop-in configuration required by FreeIPA 4.5
and higher due privilege separation work.