### PR TITLE
Add TIMEOUT parameter for update acceptor timeout.

### DIFF
--- a/freeipa-server-openshift.json
+++ b/freeipa-server-openshift.json
@@ -162,7 +162,10 @@
             },
             "spec": {
                 "strategy": {
-                    "type": "Recreate"
+                    "type": "Recreate",
+                    "recreateParams": {
+                        "timeoutSeconds": "${TIMEOUT}"
+                    }
                 },
                 "triggers": [
                     {
@@ -411,6 +414,12 @@
             "displayName": "Volume capacity",
             "required": true,
             "value": "1Gi"
+        },
+        {
+            "name": "TIMEOUT",
+            "displayName": "Timeout for pods to become ready (in seconds)",
+            "required": true,
+            "value": "600"
         }
     ]
 }


### PR DESCRIPTION
The default 10 minute timeout might be too low in some testing environment (slow network to download the image, slow CPU to run full ipa-server-install).