### PR TITLE
Use FROM registry.fedoraproject.org/fedora per https://fedoraproject.org/wiki/Container:Guidelines.

### DIFF
--- a/Dockerfile.fedora-24
+++ b/Dockerfile.fedora-24
@@ -1,5 +1,5 @@
 # Clone from the Fedora 24 image
-FROM fedora:24
+FROM registry.fedoraproject.org/fedora:24
 
 MAINTAINER Jan Pazdziora
 

--- a/Dockerfile.fedora-25
+++ b/Dockerfile.fedora-25
@@ -1,5 +1,5 @@
 # Clone from the Fedora 25 image
-FROM fedora:25
+FROM registry.fedoraproject.org/fedora:25
 
 MAINTAINER Jan Pazdziora
 

--- a/Dockerfile.fedora-25-master-nightly
+++ b/Dockerfile.fedora-25-master-nightly
@@ -1,5 +1,5 @@
 # Clone from the Fedora 25 image
-FROM fedora:25
+FROM registry.fedoraproject.org/fedora:25
 
 MAINTAINER FreeIPA Developers <freeipa-devel@redhat.com>
 

--- a/Dockerfile.fedora-rawhide
+++ b/Dockerfile.fedora-rawhide
@@ -1,5 +1,5 @@
 # Clone from the Fedora rawhide image
-FROM fedora:rawhide
+FROM registry.fedoraproject.org/fedora:rawhide
 
 MAINTAINER Jan Pazdziora
 


### PR DESCRIPTION
The guidelines document says:

The FROM instruction must be fully-qualified with a registry name, image
name, and tag as shown in this example:

	FROM registry.example.com/imagename:tag