### PR TITLE
Add support for --build-arg VERSION=<desired-version>

### DIFF
--- a/Dockerfile.centos-7
+++ b/Dockerfile.centos-7
@@ -3,7 +3,9 @@ FROM centos:centos7
 
 MAINTAINER Jan Pazdziora
 
-RUN yum install -y ipa-server ipa-server-dns ipa-server-trust-ad && yum clean all
+ARG VERSION=
+
+RUN yum install -y ipa-server${VERSION:+-${VERSION}.el7.centos.7} ipa-server-dns${VERSION:+-${VERSION}.el7.centos.7} ipa-server-trust-ad${VERSION:+-${VERSION}.el7.centos.7} && yum clean all
 
 # Workaround 1364139
 RUN sed -i '/installutils.verify_fqdn(config.master_host_name, options.no_host_dns)/s/)/, local_hostname=False)/' /usr/lib/python2.7/site-packages/ipaserver/install/server/replicainstall.py && python -m compileall /usr/lib/python2.7/site-packages/ipaserver/install/server/replicainstall.py

--- a/Dockerfile.centos-7-upstream
+++ b/Dockerfile.centos-7-upstream
@@ -3,8 +3,10 @@ FROM centos:centos7
 
 MAINTAINER Jan Pazdziora
 
+ARG VERSION=
+
 RUN cd /etc/yum.repos.d && curl -LO https://copr.fedorainfracloud.org/coprs/g/freeipa/freeipa-4-3-centos-7/repo/epel-7/pvoborni-freeipa-4-3-centos-7-epel-7.repo
-RUN yum install -y ipa-server ipa-server-dns ipa-server-trust-ad && yum clean all
+RUN yum install -y ipa-server${VERSION:+-${VERSION}.el7.centos.7} ipa-server-dns${VERSION:+-${VERSION}.el7.centos.7} ipa-server-trust-ad${VERSION:+-${VERSION}.el7.centos.7} && yum clean all
 
 # Workaround 1364139
 RUN sed -i '/installutils.verify_fqdn(config.master_host_name, options.no_host_dns)/s/)/, local_hostname=False)/' /usr/lib/python2.7/site-packages/ipaserver/install/server/replicainstall.py && python -m compileall /usr/lib/python2.7/site-packages/ipaserver/install/server/replicainstall.py

--- a/Dockerfile.fedora-23
+++ b/Dockerfile.fedora-23
@@ -3,7 +3,9 @@ FROM fedora:23
 
 MAINTAINER Jan Pazdziora
 
-RUN mkdir -p /run/lock && dnf install -y freeipa-server freeipa-server-dns freeipa-server-trust-ad && dnf clean all
+ARG VERSION=
+
+RUN mkdir -p /run/lock && dnf install -y freeipa-server${VERSION:+-${VERSION}.fc23} freeipa-server-dns${VERSION:+-${VERSION}.fc23} freeipa-server-trust-ad${VERSION:+-${VERSION}.fc23} && dnf clean all
 
 # Workaround https://fedorahosted.org/spin-kickstarts/ticket/60
 RUN [ -L /etc/systemd/system/syslog.service ] && ! [ -f /etc/systemd/system/syslog.service ] && rm -f /etc/systemd/system/syslog.service

--- a/Dockerfile.fedora-23-upstream
+++ b/Dockerfile.fedora-23-upstream
@@ -3,8 +3,10 @@ FROM fedora:23
 
 MAINTAINER Jan Pazdziora
 
+ARG VERSION=
+
 RUN cd /etc/yum.repos.d && curl -O https://copr.fedorainfracloud.org/coprs/g/freeipa/freeipa-4-3/repo/fedora-23/group_freeipa-freeipa-4-3-fedora-23.repo
-RUN mkdir -p /run/lock && dnf install -y freeipa-server freeipa-server-dns freeipa-server-trust-ad && dnf clean all
+RUN mkdir -p /run/lock && dnf install -y freeipa-server${VERSION:+-${VERSION}.fc23} freeipa-server-dns${VERSION:+-${VERSION}.fc23} freeipa-server-trust-ad${VERSION:+-${VERSION}.fc23} && dnf clean all
 
 # Workaround https://fedorahosted.org/spin-kickstarts/ticket/60
 RUN [ -L /etc/systemd/system/syslog.service ] && ! [ -f /etc/systemd/system/syslog.service ] && rm -f /etc/systemd/system/syslog.service

--- a/Dockerfile.fedora-24
+++ b/Dockerfile.fedora-24
@@ -3,7 +3,9 @@ FROM registry.fedoraproject.org/fedora:24
 
 MAINTAINER Jan Pazdziora
 
-RUN dnf upgrade -y nss && dnf install -y freeipa-server freeipa-server-dns freeipa-server-trust-ad && dnf clean all
+ARG VERSION=
+
+RUN dnf upgrade -y nss && dnf install -y freeipa-server${VERSION:+-${VERSION}.fc24} freeipa-server-dns${VERSION:+-${VERSION}.fc24} freeipa-server-trust-ad${VERSION:+-${VERSION}.fc24} && dnf clean all
 
 # Workaround 1364139
 RUN sed -i '/installutils.verify_fqdn(config.master_host_name, options.no_host_dns)/s/)/, local_hostname=False)/' /usr/lib/python2.7/site-packages/ipaserver/install/server/replicainstall.py && python -m compileall /usr/lib/python2.7/site-packages/ipaserver/install/server/replicainstall.py

--- a/Dockerfile.fedora-25
+++ b/Dockerfile.fedora-25
@@ -3,7 +3,9 @@ FROM registry.fedoraproject.org/fedora:25
 
 MAINTAINER Jan Pazdziora
 
-RUN mkdir -p /run/lock && dnf install -y freeipa-server freeipa-server-dns freeipa-server-trust-ad initscripts && dnf clean all
+ARG VERSION=
+
+RUN mkdir -p /run/lock && dnf install -y freeipa-server${VERSION:+-${VERSION}.fc25} freeipa-server-dns${VERSION:+-${VERSION}.fc25} freeipa-server-trust-ad${VERSION:+-${VERSION}.fc25} initscripts && dnf clean all
 
 # Workaround 1364139
 RUN sed -i '/installutils.verify_fqdn(config.master_host_name, options.no_host_dns)/s/)/, local_hostname=False)/' /usr/lib/python2.7/site-packages/ipaserver/install/server/replicainstall.py && python -m compileall /usr/lib/python2.7/site-packages/ipaserver/install/server/replicainstall.py

--- a/Dockerfile.fedora-25-master-nightly
+++ b/Dockerfile.fedora-25-master-nightly
@@ -3,6 +3,8 @@ FROM registry.fedoraproject.org/fedora:25
 
 MAINTAINER FreeIPA Developers <freeipa-devel@redhat.com>
 
+ARG VERSION=
+
 RUN groupadd -g 288 kdcproxy ; useradd -u 288 -g 288 -c 'IPA KDC Proxy User' -d '/var/lib/kdcproxy' -s '/sbin/nologin' kdcproxy
 RUN groupadd -g 289 ipaapi; useradd -u 289 -g 289 -c 'IPA Framework User' -d / -s '/sbin/nologin' ipaapi
 
@@ -10,9 +12,9 @@ RUN mkdir -p /run/lock \
     && cd /etc/yum.repos.d \
     && curl -O https://copr.fedorainfracloud.org/coprs/g/freeipa/freeipa-master/repo/fedora-25/group_freeipa-freeipa-master-fedora-25.repo \
     && curl -O https://copr.fedorainfracloud.org/coprs/g/freeipa/freeipa-master-nightly/repo/fedora-25/group_freeipa-freeipa-master-nightly-fedora-25.repo \
-    && dnf install -y freeipa-server \
-    freeipa-server-dns \
-    freeipa-server-trust-ad \
+    && dnf install -y freeipa-server${VERSION:+-${VERSION}.fc25} \
+    freeipa-server-dns${VERSION:+-${VERSION}.fc25} \
+    freeipa-server-trust-ad${VERSION:+-${VERSION}.fc25} \
     initscripts \
     --best --allowerasing \
     && dnf clean all

--- a/Dockerfile.fedora-rawhide
+++ b/Dockerfile.fedora-rawhide
@@ -3,7 +3,9 @@ FROM registry.fedoraproject.org/fedora:rawhide
 
 MAINTAINER Jan Pazdziora
 
-RUN mkdir -p /run/lock && dnf upgrade -y && dnf install -y freeipa-server freeipa-server-dns freeipa-server-trust-ad initscripts && dnf clean all
+ARG VERSION=
+
+RUN mkdir -p /run/lock && dnf upgrade -y && dnf install -y freeipa-server${VERSION:+-${VERISON}.fc27} freeipa-server-dns${VERSION:+-${VERISON}.fc27} freeipa-server-trust-ad${VERSION:+-${VERISON}.fc27} initscripts && dnf clean all
 
 # Workaround 1364139
 RUN sed -i '/installutils.verify_fqdn(config.master_host_name, options.no_host_dns)/s/)/, local_hostname=False)/' /usr/lib/python2.7/site-packages/ipaserver/install/server/replicainstall.py && python -m compileall /usr/lib/python2.7/site-packages/ipaserver/install/server/replicainstall.py

--- a/Dockerfile.rhel-7
+++ b/Dockerfile.rhel-7
@@ -3,7 +3,9 @@ FROM rhel7
 
 MAINTAINER Jan Pazdziora
 
-RUN yum install --disablerepo='*' --enablerepo=rhel-7-server-rpms -y ipa-server ipa-server-dns ipa-server-trust-ad && yum clean all
+ARG VERSION=
+
+RUN yum install --disablerepo='*' --enablerepo=rhel-7-server-rpms -y ipa-server${VERSION:+-${VERSION}.el7} ipa-server-dns${VERSION:+-${VERSION}.el7} ipa-server-trust-ad${VERSION:+-${VERSION}.el7} && yum clean all
 
 # Workaround 1364139
 RUN sed -i '/installutils.verify_fqdn(config.master_host_name, options.no_host_dns)/s/)/, local_hostname=False)/' /usr/lib/python2.7/site-packages/ipaserver/install/server/replicainstall.py && python -m compileall /usr/lib/python2.7/site-packages/ipaserver/install/server/replicainstall.py

--- a/Dockerfile.rhel-7-upstream
+++ b/Dockerfile.rhel-7-upstream
@@ -3,8 +3,11 @@ FROM rhel7
 
 MAINTAINER Jan Pazdziora
 
+ARG VERSION=
+
 RUN cd /etc/yum.repos.d && curl -LO https://copr.fedorainfracloud.org/coprs/g/freeipa/freeipa-4-3-centos-7/repo/epel-7/pvoborni-freeipa-4-3-centos-7-epel-7.repo
-RUN yum install --disablerepo='*' --enablerepo=rhel-7-server-rpms --enablerepo=group_freeipa-freeipa-4-3-centos-7 -y ipa-server ipa-server-dns ipa-server-trust-ad tar && yum clean all
+RUN yum install --disablerepo='*' --enablerepo=rhel-7-server-rpms --enablerepo=group_freeipa-freeipa-4-3-centos-7 -y \
+    ipa-server${VERSION:+-${VERSION}.el7} ipa-server-dns${VERSION:+-${VERSION}.el7} ipa-server-trust-ad${VERSION:+-${VERSION}.el7} tar && yum clean all
 
 RUN echo '7fe9c3084d2b8ba846c23458be86c8677693f0eb /etc/tmpfiles.d/opendnssec.conf' | sha1sum --quiet -c && mv -v /etc/tmpfiles.d/opendnssec.conf /usr/lib/tmpfiles.d/opendnssec.conf
 RUN echo '5a70f1f3db0608c156d5b6629d4cbc3b304fc045 /etc/systemd/system/sssd.service.d/journal.conf' | sha1sum --quiet -c && rm -vf /etc/systemd/system/sssd.service.d/journal.conf

--- a/README
+++ b/README
@@ -19,6 +19,13 @@ The repository contains multiple `Dockerfile`s for various
 operating systems. Use `-f` option to `docker build` to pick
 different than default target.
 
+If you wish to specify the exact version used, you can pass a build arg
+to do so.  This should only be used if you're trying to lock the version
+of freeipa temporarily, and have accounted for any Dockerfile changes.
+An example invocation for fedora-25, building 4.4.4-1 would be:
+
+    docker build -t freeipa-server -f Dockerfile.fedora-25 --build-arg VERSION=4.4.4-1 .
+
 Create directory which will hold the server data:
 
     mkdir /var/lib/ipa-data


### PR DESCRIPTION
In rebuilding the container, we may wish to uprade a component in the OS
image, but *not* bump forward to the latest freeipa version the upstream
OS provides.

This is semi-advanced usage.  If a user is forcing an older version, they're
responsible for the potential build failures; however, we should give
them the option to at least lock the version if they wish.

This has been validated for all Dockerfile targets except for rhel7;
I do not have access to rhel7 to test.