### PR TITLE
Update freeipa-devel email

### DIFF
--- a/Dockerfile.fedora-25-master-nightly
+++ b/Dockerfile.fedora-25-master-nightly
@@ -1,7 +1,7 @@
 # Clone from the Fedora 25 image
 FROM registry.fedoraproject.org/fedora:25
 
-MAINTAINER FreeIPA Developers <freeipa-devel@redhat.com>
+MAINTAINER FreeIPA Developers <freeipa-devel@lists.fedorahosted.org>
 
 RUN groupadd -g 288 kdcproxy ; useradd -u 288 -g 288 -c 'IPA KDC Proxy User' -d '/var/lib/kdcproxy' -s '/sbin/nologin' kdcproxy
 RUN groupadd -g 289 ipaapi; useradd -u 289 -g 289 -c 'IPA Framework User' -d / -s '/sbin/nologin' ipaapi


### PR DESCRIPTION
Freeipa-devel mailing list has been migrated to
freeipa-devel@lists.fedorahosted.org