### PR TITLE
Extend non-local ip addresses workaround bz#1377973

### DIFF
--- a/Dockerfile.fedora-25
+++ b/Dockerfile.fedora-25
@@ -9,6 +9,7 @@ RUN mkdir -p /run/lock && dnf install -y freeipa-server freeipa-server-dns freei
 RUN sed -i '/installutils.verify_fqdn(config.master_host_name, options.no_host_dns)/s/)/, local_hostname=False)/' /usr/lib/python2.7/site-packages/ipaserver/install/server/replicainstall.py && python -m compileall /usr/lib/python2.7/site-packages/ipaserver/install/server/replicainstall.py
 # Workaround 1377973
 RUN sed -i 's/ips.append(ipautil.CheckedIPAddress(ha, match_local=True))/ips.append(ipautil.CheckedIPAddress(ha, match_local=False))/' /usr/lib/python2.7/site-packages/ipaserver/install/installutils.py && python -m compileall /usr/lib/python2.7/site-packages/ipaserver/install/installutils.py
+RUN sed -i "s/(list, 'ip-local')/(list, 'ip')/" /usr/lib/python2.7/site-packages/ipaserver/install/server/common.py && python -m compileall /usr/lib/python2.7/site-packages/ipaserver/install/server/common.py
 # Workaround https://fedorahosted.org/freeipa/ticket/6518
 RUN sed -i 's/getaddrinfo(fqdn/getaddrinfo(fqdn.rstrip(".")/' /usr/lib/python2.7/site-packages/ipaserver/install/installutils.py && python -m compileall /usr/lib/python2.7/site-packages/ipaserver/install/installutils.py
 # Workaround https://fedorahosted.org/spin-kickstarts/ticket/60

--- a/Dockerfile.fedora-26
+++ b/Dockerfile.fedora-26
@@ -9,6 +9,7 @@ RUN mkdir -p /run/lock && dnf install -y freeipa-server freeipa-server-dns freei
 RUN sed -i '/installutils.verify_fqdn(config.master_host_name, options.no_host_dns)/s/)/, local_hostname=False)/' /usr/lib/python2.7/site-packages/ipaserver/install/server/replicainstall.py && python -m compileall /usr/lib/python2.7/site-packages/ipaserver/install/server/replicainstall.py
 # Workaround 1377973
 RUN sed -i 's/ips.append(ipautil.CheckedIPAddress(ha, match_local=True))/ips.append(ipautil.CheckedIPAddress(ha, match_local=False))/' /usr/lib/python2.7/site-packages/ipaserver/install/installutils.py && python -m compileall /usr/lib/python2.7/site-packages/ipaserver/install/installutils.py
+RUN sed -i "s/(list, 'ip-local')/(list, 'ip')/" /usr/lib/python2.7/site-packages/ipaserver/install/server/common.py && python -m compileall /usr/lib/python2.7/site-packages/ipaserver/install/server/common.py
 # Workaround https://fedorahosted.org/freeipa/ticket/6518
 RUN sed -i 's/getaddrinfo(fqdn/getaddrinfo(fqdn.rstrip(".")/' /usr/lib/python2.7/site-packages/ipaserver/install/installutils.py && python -m compileall /usr/lib/python2.7/site-packages/ipaserver/install/installutils.py
 # Workaround https://fedorahosted.org/spin-kickstarts/ticket/60


### PR DESCRIPTION
In FreeIPA 4.4, validation of ip-address slightly changed so we have to
extend workaround.