### PR TITLE
Ensure stable UIDs/GIDs, something that sadly rpms do not provide.

### DIFF
--- a/Dockerfile.fedora-rawhide
+++ b/Dockerfile.fedora-rawhide
@@ -3,6 +3,8 @@ FROM registry.fedoraproject.org/fedora:rawhide
 
 MAINTAINER Jan Pazdziora
 
+RUN groupadd -g 288 kdcproxy ; useradd -u 288 -g 288 -c 'IPA KDC Proxy User' -d '/var/lib/kdcproxy' -s '/sbin/nologin' kdcproxy
+
 RUN mkdir -p /run/lock && dnf upgrade -y && dnf install -y freeipa-server freeipa-server-dns freeipa-server-trust-ad initscripts && dnf clean all
 
 # Workaround 1364139
@@ -42,8 +44,6 @@ RUN systemctl set-default container-ipa.target
 RUN systemctl enable ipa-server-configure-first.service
 
 COPY exit-via-chroot.conf /usr/lib/systemd/system/systemd-poweroff.service.d/
-
-RUN groupadd -g 288 kdcproxy ; useradd -u 288 -g 288 -c 'IPA KDC Proxy User' -d '/var/lib/kdcproxy' -s '/sbin/nologin' kdcproxy
 
 COPY atomic-install-help /usr/share/ipa/
 COPY volume-data-list volume-data-mv-list volume-data-autoupdate /etc/


### PR DESCRIPTION
Similar to 83caaf36e1c8b1405edfaa346f20cf49bb707788.

Addressing
```
Step 29 : RUN groupadd -g 288 kdcproxy ; useradd -u 288 -g 288 -c 'IPA KDC Proxy User' -d '/var/lib/kdcproxy' -s '/sbin/nologin' kdcproxy
 ---> Running in ba7a5b8b83fe
groupadd: group 'kdcproxy' already exists
useradd: group '288' does not exist
The command '/bin/sh -c groupadd -g 288 kdcproxy ; useradd -u 288 -g 288 -c 'IPA KDC Proxy User' -d '/var/lib/kdcproxy' -s '/sbin/nologin' kdcproxy' returned a non-zero code: 6
```