### PR TITLE
Add script debugging options

### DIFF
--- a/README
+++ b/README
@@ -162,6 +162,23 @@ freeipa-server container directly:
 The first time this container runs, it invokes `ipa-client-install`
 with the given admin password.
 
+# Debugging
+
+The container scripts provide some options for debugging:
+
+- Enable shell script tracing in both the top-level `init-data` script
+  and the `ipa-server-configure-first` script by setting the
+  `$DEBUG_TRACE` environment variable.
+
+- Disable container exit after script failure by setting the
+  `$DEBUG_NO_EXIT` environment variable.  After failure, the
+  container will continue running, and can be entered for debugging
+  with e.g. `docker exec -it freeipa-server-container bash`.
+
+Example usage:
+
+    docker run [...] -e DEBUG_TRACE=1 -e DEBUG_NO_EXIT=1 freeipa-server
+
 # Copyright 2014--2016 Jan Pazdziora
 
 Licensed under the Apache License, Version 2.0 (the "License");

--- a/init-data
+++ b/init-data
@@ -19,6 +19,9 @@
 
 set -e
 
+# Turn on tracing of this script
+test -z "$DEBUG_TRACE" || set -x
+
 cd /
 
 case "$1" in
@@ -48,6 +51,23 @@ if [ "$1" == 'exit-on-finished' ] ; then
 else
 	touch /run/ipa/exit-on-error
 fi
+
+# Debugging:  Turn on tracing of ipa-server-configure-first script
+test -z "$DEBUG_TRACE" || touch /run/ipa/debug-trace
+
+# Debugging:  Don't power off if IPA install/upgrade fails
+for i in ipa-server-configure-first.service ipa-server-upgrade.service; do
+    if [ -n "$DEBUG_NO_EXIT" ]; then
+	# Create service drop-in to override `FailureAction`
+	mkdir -p /data/etc/systemd/system/${i}.d
+	echo -e "[Service]\nFailureAction=none" > \
+	    /data/etc/systemd/system/${i}.d/50-no-poweroff.conf
+    else
+	# Debugging off:  Remove service drop-in
+	rm -f /data/etc/systemd/system/${i}.d/50-no-poweroff.conf
+    fi
+
+done
 
 DATA=/data
 COMMAND=

--- a/ipa-server-configure-first
+++ b/ipa-server-configure-first
@@ -24,6 +24,8 @@ trap mark_exit_code ERR EXIT
 
 set -e
 
+test ! -f /run/ipa/debug-trace || set -x
+
 HOSTNAME=$( cat /data/hostname )
 
 function update_server_ip_address () {


### PR DESCRIPTION
Add two environment variables that may be defined with `docker run -e`
to aid debugging:

- Define `$DEBUG_TRACE` to turn on `init-data` and
  `ipa-server-configure-first` script tracing

- Define `$DEBUG_NO_EXIT` to disable container exit after failures