### PR TITLE
Fix `/etc/dirsrv/schema` relocation

### DIFF
--- a/Dockerfile.fedora-25-master-nightly
+++ b/Dockerfile.fedora-25-master-nightly
@@ -62,7 +62,6 @@ RUN rm -rf /var/log-removed
 RUN sed -i 's!^d /var/log.*!L /var/log - - - - /data/var/log!' /usr/lib/tmpfiles.d/var.conf
 # Workaround 1286602
 RUN mv /usr/lib/tmpfiles.d/journal-nocow.conf /usr/lib/tmpfiles.d/journal-nocow.conf.disabled
-RUN mv /data-template/etc/dirsrv/schema /usr/share/dirsrv/schema && ln -s /usr/share/dirsrv/schema /data-template/etc/dirsrv/schema
 RUN rm -f /data-template/var/lib/systemd/random-seed
 RUN echo 1.1 > /etc/volume-version
 

--- a/Dockerfile.fedora-rawhide
+++ b/Dockerfile.fedora-rawhide
@@ -52,7 +52,6 @@ RUN rm -rf /var/log-removed
 RUN sed -i 's!^d /var/log.*!L /var/log - - - - /data/var/log!' /usr/lib/tmpfiles.d/var.conf
 # Workaround 1286602
 RUN mv /usr/lib/tmpfiles.d/journal-nocow.conf /usr/lib/tmpfiles.d/journal-nocow.conf.disabled
-RUN mv /data-template/etc/dirsrv/schema /usr/share/dirsrv/schema && ln -s /usr/share/dirsrv/schema /data-template/etc/dirsrv/schema
 RUN rm -f /data-template/var/lib/systemd/random-seed
 RUN echo 1.1 > /etc/volume-version
 


### PR DESCRIPTION
Changes in f26 and later `389-ds-base` add `/usr/share/dirsrv/schema`
to packaging, which breaks the Dockerfile `/etc/dirsrv/schema`
relocation.

Instead of moving the whole directory, move just the contents.

Related to #157, "Support for FreeIPA v. 4.5".