### PR TITLE
Avoid runtime changes in /var/lib/dbus/machine-id.

### DIFF
--- a/Dockerfile.fedora-26
+++ b/Dockerfile.fedora-26
@@ -5,6 +5,7 @@ MAINTAINER FreeIPA Developers <freeipa-devel@lists.fedorahosted.org>
 
 RUN mkdir -p /run/lock && dnf install -y freeipa-server freeipa-server-dns freeipa-server-trust-ad initscripts && dnf clean all
 
+RUN mkdir -p /var/lib/dbus && ln -s /etc/machine-id /var/lib/dbus/machine-id
 # Workaround 1364139
 RUN sed -i '/installutils.verify_fqdn(config.master_host_name, options.no_host_dns)/s/)/, local_hostname=False)/' /usr/lib/python2.7/site-packages/ipaserver/install/server/replicainstall.py && python -m compileall /usr/lib/python2.7/site-packages/ipaserver/install/server/replicainstall.py
 # Workaround 1377973


### PR DESCRIPTION
Untested, should be mostly equivalent to https://github.com/freeipa/freeipa-container/pull/161.

This should make `docker diff` pass, at least on Fedora 25 hosts.