### PR TITLE
Make Fedora 26 the base for nightly container

### DIFF
--- a/Dockerfile.fedora-26-master-nightly
+++ b/Dockerfile.fedora-26-master-nightly
@@ -1,5 +1,5 @@
-# Clone from the Fedora 25 image
-FROM registry.fedoraproject.org/fedora:25
+# Clone from the Fedora 26 image
+FROM registry.fedoraproject.org/fedora:26
 
 MAINTAINER FreeIPA Developers <freeipa-devel@lists.fedorahosted.org>
 
@@ -8,8 +8,8 @@ RUN groupadd -g 289 ipaapi; useradd -u 289 -g 289 -c 'IPA Framework User' -d / -
 
 RUN mkdir -p /run/lock \
     && cd /etc/yum.repos.d \
-    && curl -O https://copr.fedorainfracloud.org/coprs/g/freeipa/freeipa-master/repo/fedora-25/group_freeipa-freeipa-master-fedora-25.repo \
-    && curl -O https://copr.fedorainfracloud.org/coprs/g/freeipa/freeipa-master-nightly/repo/fedora-25/group_freeipa-freeipa-master-nightly-fedora-25.repo \
+    && curl -O https://copr.fedorainfracloud.org/coprs/g/freeipa/freeipa-master/repo/fedora-26/group_freeipa-freeipa-master-fedora-26.repo \
+    && curl -O https://copr.fedorainfracloud.org/coprs/g/freeipa/freeipa-master-nightly/repo/fedora-26/group_freeipa-freeipa-master-nightly-fedora-26.repo \
     && dnf install -y freeipa-server \
     freeipa-server-dns \
     freeipa-server-trust-ad \


### PR DESCRIPTION
The @freeipa/freeipa-master copr repo does not offer rpms for
Fedora 25 anymore, switch to Fedora 26 instead.