### PR TITLE
Remove workaround configuring locale

### DIFF
--- a/Dockerfile.fedora-25
+++ b/Dockerfile.fedora-25
@@ -25,8 +25,6 @@ RUN for i in basic.target network.service netconsole.service ; do rm -f /usr/lib
 RUN rm -fv /usr/lib/systemd/system/sysinit.target.wants/*
 RUN echo 'disable *' > /usr/lib/systemd/system-preset/10-container-disable.preset
 
-RUN echo LANG=C > /etc/locale.conf
-
 RUN /sbin/ldconfig -X
 
 COPY init-data /usr/local/sbin/init

--- a/Dockerfile.fedora-26
+++ b/Dockerfile.fedora-26
@@ -23,8 +23,6 @@ RUN for i in basic.target network.service netconsole.service ; do rm -f /usr/lib
 RUN rm -fv /usr/lib/systemd/system/sysinit.target.wants/*
 RUN echo 'disable *' > /usr/lib/systemd/system-preset/10-container-disable.preset
 
-RUN echo LANG=C > /etc/locale.conf
-
 RUN /sbin/ldconfig -X
 
 COPY init-data /usr/local/sbin/init

--- a/Dockerfile.fedora-26-master-nightly
+++ b/Dockerfile.fedora-26-master-nightly
@@ -37,8 +37,6 @@ RUN echo 'disable *' > /usr/lib/systemd/system-preset/10-container-disable.prese
 # Workaround https://bugzilla.redhat.com/show_bug.cgi?id=1433050
 RUN sed -i -E 's/(Requires=proc-fs-nfsd.mount)/#\1/'  /usr/lib/systemd/system/gssproxy.service
 
-RUN echo LANG=C > /etc/locale.conf
-
 RUN /sbin/ldconfig -X
 
 COPY init-data /usr/local/sbin/init

--- a/Dockerfile.fedora-27
+++ b/Dockerfile.fedora-27
@@ -21,8 +21,6 @@ RUN for i in basic.target network.service netconsole.service ; do rm -f /usr/lib
 RUN rm -fv /usr/lib/systemd/system/sysinit.target.wants/*
 RUN echo 'disable *' > /usr/lib/systemd/system-preset/10-container-disable.preset
 
-RUN echo LANG=C > /etc/locale.conf
-
 RUN /sbin/ldconfig -X
 
 COPY init-data /usr/local/sbin/init

--- a/Dockerfile.fedora-rawhide
+++ b/Dockerfile.fedora-rawhide
@@ -21,8 +21,6 @@ RUN for i in basic.target network.service netconsole.service ; do rm -f /usr/lib
 RUN rm -fv /usr/lib/systemd/system/sysinit.target.wants/*
 RUN echo 'disable *' > /usr/lib/systemd/system-preset/10-container-disable.preset
 
-RUN echo LANG=C > /etc/locale.conf
-
 RUN /sbin/ldconfig -X
 
 COPY init-data /usr/local/sbin/init


### PR DESCRIPTION
This removes the workaround originally introduced for
https://bugzilla.redhat.com/show_bug.cgi?id=1343129 which seems to
be fixed now.