### PR TITLE
f26nightly: Remove sha1sum check of sssd journal.conf

### DIFF
--- a/Dockerfile.fedora-26-master-nightly
+++ b/Dockerfile.fedora-26-master-nightly
@@ -29,7 +29,6 @@ RUN sed -i 's/getaddrinfo(fqdn/getaddrinfo(fqdn.rstrip(".")/' /usr/lib/python2.7
 RUN [ -L /etc/systemd/system/syslog.service ] && ! [ -f /etc/systemd/system/syslog.service ] && rm -f /etc/systemd/system/syslog.service
 
 RUN echo 'd0a98590c74bfe36af0ce006f7b25fa60246aecb /etc/tmpfiles.d/opendnssec.conf' | sha1sum --quiet -c && mv -v /etc/tmpfiles.d/opendnssec.conf /usr/lib/tmpfiles.d/opendnssec.conf
-RUN echo 'd2090704dc077e75a70420a5ee2534b7148bb35d /etc/systemd/system/sssd.service.d/journal.conf' | sha1sum --quiet -c && rm -vf /etc/systemd/system/sssd.service.d/journal.conf
 RUN find /etc/systemd/system/* '!' -name '*.wants' | xargs rm -rvf
 RUN for i in basic.target network.service netconsole.service ; do rm -f /usr/lib/systemd/system/$i && ln -s /dev/null /usr/lib/systemd/system/$i ; done
 RUN rm -fv /usr/lib/systemd/system/sysinit.target.wants/*


### PR DESCRIPTION
SSSD no longer uses journal.conf, build fails on sha1sum check