### PR TITLE
Make Dockerfile point to Dockerfile.fedora-26

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,1 @@
-Dockerfile.fedora-25
+Dockerfile.fedora-26


### PR DESCRIPTION
Fedora 25 is reaching EOL and freeIPA Fedora 26 image seems to be
stable, mark it as latest.