### PR TITLE
Add HOME env var to ipa-server-configure.service

### DIFF
--- a/ipa-server-configure-first.service
+++ b/ipa-server-configure-first.service
@@ -3,6 +3,7 @@ Description=Configure IPA server upon the first start
 
 [Service]
 Type=oneshot
+Environment="RANDFILE=/dev/null"
 ExecStart=/usr/sbin/ipa-server-configure-first
 ExecStartPost=/usr/sbin/ipa-server-status-check
 FailureAction=poweroff


### PR DESCRIPTION
OpenSSL requires at least one of HOME or RANDFILE environment
variables to be set for it to work.

Without this fix, the external CA setup crashes because OpenSSL
is unable to write its random state anywhere when it tries to
generate a CSR for the external CA to sign.