### PR TITLE
Revert "Let oci-systemd-hook create journal directory before /data is mounted.

### DIFF
--- a/Dockerfile.centos-7
+++ b/Dockerfile.centos-7
@@ -55,7 +55,7 @@ ENV container docker
 
 EXPOSE 53/udp 53 80 443 389 636 88 464 88/udp 464/udp 123/udp 7389 9443 9444 9445
 
-VOLUME [ "/tmp", "/run", "/data", "/var/log/journal" ]
+VOLUME [ "/tmp", "/run", "/data" ]
 
 STOPSIGNAL RTMIN+3
 ENTRYPOINT [ "/usr/local/sbin/init" ]

--- a/Dockerfile.centos-7-upstream
+++ b/Dockerfile.centos-7-upstream
@@ -54,7 +54,7 @@ ENV container docker
 
 EXPOSE 53/udp 53 80 443 389 636 88 464 88/udp 464/udp 123/udp 7389 9443 9444 9445
 
-VOLUME [ "/tmp", "/run", "/data", "/var/log/journal" ]
+VOLUME [ "/tmp", "/run", "/data" ]
 
 STOPSIGNAL RTMIN+3
 ENTRYPOINT [ "/usr/local/sbin/init" ]

--- a/Dockerfile.fedora-23
+++ b/Dockerfile.fedora-23
@@ -55,7 +55,7 @@ ENV container docker
 
 EXPOSE 53/udp 53 80 443 389 636 88 464 88/udp 464/udp 123/udp 7389 9443 9444 9445
 
-VOLUME [ "/tmp", "/run", "/data", "/var/log/journal" ]
+VOLUME [ "/tmp", "/run", "/data" ]
 
 STOPSIGNAL RTMIN+3
 ENTRYPOINT [ "/usr/local/sbin/init" ]

--- a/Dockerfile.fedora-23-upstream
+++ b/Dockerfile.fedora-23-upstream
@@ -56,7 +56,7 @@ ENV container docker
 
 EXPOSE 53/udp 53 80 443 389 636 88 464 88/udp 464/udp 123/udp 7389 9443 9444 9445
 
-VOLUME [ "/tmp", "/run", "/data", "/var/log/journal" ]
+VOLUME [ "/tmp", "/run", "/data" ]
 
 STOPSIGNAL RTMIN+3
 ENTRYPOINT [ "/usr/local/sbin/init" ]

--- a/Dockerfile.fedora-24
+++ b/Dockerfile.fedora-24
@@ -59,7 +59,7 @@ ENV container docker
 
 EXPOSE 53/udp 53 80 443 389 636 88 464 88/udp 464/udp 123/udp 7389 9443 9444 9445
 
-VOLUME [ "/tmp", "/run", "/data", "/var/log/journal" ]
+VOLUME [ "/tmp", "/run", "/data" ]
 
 STOPSIGNAL RTMIN+3
 ENTRYPOINT [ "/usr/local/sbin/init" ]

--- a/Dockerfile.fedora-25
+++ b/Dockerfile.fedora-25
@@ -61,7 +61,7 @@ ENV container docker
 
 EXPOSE 53/udp 53 80 443 389 636 88 464 88/udp 464/udp 123/udp 7389 9443 9444 9445
 
-VOLUME [ "/tmp", "/run", "/data", "/var/log/journal" ]
+VOLUME [ "/tmp", "/run", "/data" ]
 
 STOPSIGNAL RTMIN+3
 ENTRYPOINT [ "/usr/local/sbin/init" ]

--- a/Dockerfile.fedora-26
+++ b/Dockerfile.fedora-26
@@ -57,7 +57,7 @@ ENV container docker
 
 EXPOSE 53/udp 53 80 443 389 636 88 464 88/udp 464/udp 123/udp 7389 9443 9444 9445
 
-VOLUME [ "/tmp", "/run", "/data", "/var/log/journal" ]
+VOLUME [ "/tmp", "/run", "/data" ]
 
 STOPSIGNAL RTMIN+3
 ENTRYPOINT [ "/usr/local/sbin/init" ]

--- a/Dockerfile.fedora-26-master-nightly
+++ b/Dockerfile.fedora-26-master-nightly
@@ -69,7 +69,7 @@ ENV container docker
 
 EXPOSE 53/udp 53 80 443 389 636 88 464 88/udp 464/udp 123/udp 7389 9443 9444 9445
 
-VOLUME [ "/tmp", "/run", "/data", "/var/log/journal" ]
+VOLUME [ "/tmp", "/run", "/data" ]
 
 STOPSIGNAL RTMIN+3
 ENTRYPOINT [ "/usr/local/sbin/init" ]

--- a/Dockerfile.fedora-27
+++ b/Dockerfile.fedora-27
@@ -53,7 +53,7 @@ ENV container docker
 
 EXPOSE 53/udp 53 80 443 389 636 88 464 88/udp 464/udp 123/udp 7389 9443 9444 9445
 
-VOLUME [ "/tmp", "/run", "/data", "/var/log/journal" ]
+VOLUME [ "/tmp", "/run", "/data" ]
 
 STOPSIGNAL RTMIN+3
 ENTRYPOINT [ "/usr/local/sbin/init" ]

--- a/Dockerfile.fedora-rawhide
+++ b/Dockerfile.fedora-rawhide
@@ -53,7 +53,7 @@ ENV container docker
 
 EXPOSE 53/udp 53 80 443 389 636 88 464 88/udp 464/udp 123/udp 7389 9443 9444 9445
 
-VOLUME [ "/tmp", "/run", "/data", "/var/log/journal" ]
+VOLUME [ "/tmp", "/run", "/data" ]
 
 STOPSIGNAL RTMIN+3
 ENTRYPOINT [ "/usr/local/sbin/init" ]

--- a/Dockerfile.rhel-7
+++ b/Dockerfile.rhel-7
@@ -55,7 +55,7 @@ ENV container docker
 
 EXPOSE 53/udp 53 80 443 389 636 88 464 88/udp 464/udp 123/udp 7389 9443 9444 9445
 
-VOLUME [ "/tmp", "/run", "/data", "/var/log/journal" ]
+VOLUME [ "/tmp", "/run", "/data" ]
 
 STOPSIGNAL RTMIN+3
 ENTRYPOINT [ "/usr/local/sbin/init" ]

--- a/Dockerfile.rhel-7-upstream
+++ b/Dockerfile.rhel-7-upstream
@@ -49,7 +49,7 @@ ENV container docker
 
 EXPOSE 53/udp 53 80 443 389 636 88 464 88/udp 464/udp 123/udp 7389 9443 9444 9445
 
-VOLUME [ "/tmp", "/run", "/data", "/var/log/journal" ]
+VOLUME [ "/tmp", "/run", "/data" ]
 
 STOPSIGNAL RTMIN+3
 ENTRYPOINT [ "/usr/local/sbin/init" ]


### PR DESCRIPTION
This reverts commit ede29f7531fad3ff38dee7634e3eefc8530bed8c.

Addressing buildah build issue
```
STEP 39: VOLUME [ "/tmp", "/run", "/data", "/var/log/journal" ]
error building: error building at step {Env:[container=docker DISTTAG=f26container FGC=f26   PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin container=docker] Command:volume Args:[/tmp /run /data /var/log/journal] Flags:[] Attrs:map[json:true] Message:VOLUME /tmp /run /data /var/log/journal Original:VOLUME [ "/tmp", "/run", "/data", "/var/log/journal" ]}: error ensuring volume path "/var/lib/containers/storage/overlay/6316033d1eacdd9a3e2065019bf8b196b057fa36326980f2760f51f2b40f4910/merged/var/log/journal" exists: mkdir /var/lib/containers/storage/overlay/6316033d1eacdd9a3e2065019bf8b196b057fa36326980f2760f51f2b40f4910/merged/var/log: file exists
```

I have only tested this on Fedora 27 with docker-1.13.1-44.git584d391.fc27.x86_64 where it did not cause regression.