### PR TITLE
Make Dockerfile point to Dockerfile.fedora-27.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,1 @@
-Dockerfile.fedora-26
+Dockerfile.fedora-27


### PR DESCRIPTION
Fedora 26 is reaching EOL and Fedora 27 image seems to be stable, mark
it as the default.