### PR TITLE
Do not create /var/lib/dbus/machine-id symlink if it already exists.

### DIFF
--- a/Dockerfile.fedora-27
+++ b/Dockerfile.fedora-27
@@ -8,7 +8,7 @@ RUN groupadd -g 289 ipaapi; useradd -u 289 -g 289 -c 'IPA Framework User' -d / -
 
 RUN mkdir -p /run/lock && dnf upgrade -y && dnf install -y freeipa-server freeipa-server-dns freeipa-server-trust-ad initscripts && dnf clean all
 
-RUN mkdir -p /var/lib/dbus && ln -s /etc/machine-id /var/lib/dbus/machine-id
+RUN test -L /var/lib/dbus/machine-id || ( mkdir -p /var/lib/dbus && ln -s /etc/machine-id /var/lib/dbus/machine-id )
 # Workaround 1364139
 RUN sed -i '/installutils.verify_fqdn(config.master_host_name, options.no_host_dns)/s/)/, local_hostname=False)/' /usr/lib/python2.7/site-packages/ipaserver/install/server/replicainstall.py && python -m compileall /usr/lib/python2.7/site-packages/ipaserver/install/server/replicainstall.py
 RUN sed -i '/installutils.verify_fqdn(config.master_host_name, options.no_host_dns)/s/)/, local_hostname=False)/' /usr/lib/python3.6/site-packages/ipaserver/install/server/replicainstall.py && python3 -m compileall /usr/lib/python3.6/site-packages/ipaserver/install/server/replicainstall.py


### PR DESCRIPTION
Addressing
```
Step 6/46 : RUN mkdir -p /var/lib/dbus && ln -s /etc/machine-id /var/lib/dbus/machine-id
 ---> Running in 2c0b201b759b
ln: failed to create symbolic link '/var/lib/dbus/machine-id': File exists
```
The symlink gets created by `systemd`'s postinstall scriptlet calling `systemd-tmpfiles --create` during the previous `dnf upgrade` step.