### PR TITLE
Fedora rawhide uses nis-domainname.service instead of fedora-domainname.service.

### DIFF
--- a/Dockerfile.fedora-rawhide
+++ b/Dockerfile.fedora-rawhide
@@ -24,9 +24,9 @@ COPY init-data /usr/local/sbin/init
 COPY ipa-server-configure-first ipa-server-status-check exit-with-status ipa-volume-upgrade-* /usr/sbin/
 COPY install.sh uninstall.sh /bin/
 RUN mv /bin/hostnamectl /bin/hostnamectl.orig
-RUN mv /usr/bin/domainname /usr/bin/domainname.orig
+RUN mv /usr/bin/nisdomainname /usr/bin/nisdomainname.orig
 ADD hostnamectl-wrapper /bin/hostnamectl
-ADD hostnamectl-wrapper /usr/bin/domainname
+ADD hostnamectl-wrapper /usr/bin/nisdomainname
 RUN chmod -v +x /usr/local/sbin/init /usr/sbin/ipa-server-configure-first /usr/sbin/ipa-server-status-check /usr/sbin/exit-with-status /usr/sbin/ipa-volume-upgrade-* /bin/install.sh /bin/uninstall.sh /bin/hostnamectl /usr/bin/domainname
 COPY container-ipa.target ipa-server-configure-first.service ipa-server-upgrade.service ipa-server-update-self-ip-address.service /usr/lib/systemd/system/
 RUN rmdir -v /etc/systemd/system/multi-user.target.wants \

--- a/hostnamectl-wrapper
+++ b/hostnamectl-wrapper
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if setpriv --dump | grep -q sys_admin ; then
-	if [ "$( basename $0 )" == "domainname" ] ; then
+	if [[ "$( basename $0 )" =~ "domainname" ]] ; then
 		/usr/bin/hostname -y "$@"
 	else
 		$0.orig "$@"


### PR DESCRIPTION
Fedora rawhide uses `nis-domainname.service` instead of `fedora-domainname.service`.

It in turn invokes `/usr/libexec/hostname/nis-domainname` which then calls `nisdomainname`, instead of `/usr/lib/systemd/fedora-domainname` which called `/usr/bin/domainname`.

Addressing
```
CalledProcessError(Command ['/bin/systemctl', 'restart', 'nis-domainname.service'] returned non-zero exit status 1: 'Job for nis-domainname.service failed because the control process exited with error code.\nSee "systemctl status nis-domainname.service" and "journalctl -xe" for details.\n')
The ipa-client-install command failed. See /var/log/ipaclient-install.log for more information
ipapython.admintool: ERROR    Configuration of client side components failed!
ipapython.admintool: ERROR    The ipa-server-install command failed. See /var/log/ipaserver-install.log for more information
```