### PR TITLE
Do not refresh $DATA in the second stage of the external CA setup.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,5 +46,4 @@ matrix:
       env: dockerfile=rhel-7
 
 script:
-- if grep -F "Dockerfile.$dockerfile" <( echo "$BUILD_DOCKERFILES" ) ; then docker build -t local/freeipa-server -f Dockerfile.$dockerfile . ; else echo "Skipping, Dockerfile.$dockerfile not modified." ; fi
-- if docker images | grep local/freeipa-server ; then docker run $privileged -h ipa.example.test --sysctl net.ipv6.conf.all.disable_ipv6=0 --tmpfs /run --tmpfs /tmp -v /dev/urandom:/dev/random:ro -v /sys/fs/cgroup:/sys/fs/cgroup:ro -e PASSWORD=Secret123 local/freeipa-server exit-on-finished -U -r EXAMPLE.TEST --setup-dns --no-forwarders --no-ntp ; fi
+- tests/build-and-run.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ before_script:
 - export TRAVIS_DOCKERFILES=$( sed 's/^ *env. dockerfile=/Dockerfile./;s/ .*//;/^Dockerfile/p;d' .travis.yml | sort ) && echo "$TRAVIS_DOCKERFILES"
 - export BUILD_DOCKERFILES=$( grep '^Dockerfile\.' <( echo "$FILES_CHANGED" ) ) ; echo "$BUILD_DOCKERFILES"
 - export NONDOCKERFILES_CHANGED=$( grep -v '^Dockerfile\.' <( echo "$FILES_CHANGED" ) ) ; echo "$NONDOCKERFILES_CHANGED"
-- if test -n "$NONDOCKERFILES_CHANGED" ; then export BUILD_DOCKERFILES=$TRAVIS_DOCKERFILES ; fi ; echo "$BUILD_DOCKERFILES"
+- if test -z "$FILES_CHANGED" || test -n "$NONDOCKERFILES_CHANGED" ; then export BUILD_DOCKERFILES=$TRAVIS_DOCKERFILES ; fi ; echo "$BUILD_DOCKERFILES"
 - env | sort
 
 stages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ sudo: required
 services:
 - docker
 
+before_install:
+- sudo apt-get install -y libnss3-tools
+
 install: true
 
 before_script:
@@ -30,11 +33,17 @@ matrix:
     - stage: build
       env: dockerfile=fedora-28 privileged=--privileged
     - stage: build
+      env: dockerfile=fedora-28 ca=--external-ca privileged=--privileged
+    - stage: build
       env: dockerfile=fedora-27 privileged=--privileged
     - stage: build
       env: dockerfile=fedora-26 privileged=--privileged
     - stage: build
+      env: dockerfile=fedora-26 ca=--external-ca privileged=--privileged
+    - stage: build
       env: dockerfile=centos-7
+    - stage: build
+      env: dockerfile=centos-7 ca=--external-ca
   exclude:
     - stage: build
       env: dockerfile=fedora-25

--- a/Dockerfile.fedora-27
+++ b/Dockerfile.fedora-27
@@ -14,6 +14,8 @@ RUN sed -i '/installutils.verify_fqdn(config.master_host_name, options.no_host_d
 RUN sed -i '/installutils.verify_fqdn(config.master_host_name, options.no_host_dns)/s/)/, local_hostname=False)/' /usr/lib/python3.6/site-packages/ipaserver/install/server/replicainstall.py && python3 -m compileall /usr/lib/python3.6/site-packages/ipaserver/install/server/replicainstall.py
 # Workaround https://fedorahosted.org/spin-kickstarts/ticket/60
 RUN [ -L /etc/systemd/system/syslog.service ] && ! [ -f /etc/systemd/system/syslog.service ] && rm -f /etc/systemd/system/syslog.service
+# Workaround https://github.com/freeipa/freeipa-container/issues/187
+COPY certmonger-wait-for-ready.conf /usr/lib/systemd/system/certmonger.service.d/wait-for-ready.conf
 
 RUN find /etc/systemd/system/* '!' -name '*.wants' | xargs rm -rvf
 RUN for i in basic.target network.service netconsole.service ; do rm -f /usr/lib/systemd/system/$i && ln -s /dev/null /usr/lib/systemd/system/$i ; done

--- a/Dockerfile.fedora-28
+++ b/Dockerfile.fedora-28
@@ -12,6 +12,8 @@ RUN dnf upgrade -y && dnf install -y freeipa-server freeipa-server-dns freeipa-s
 RUN sed -i '/installutils.verify_fqdn(config.master_host_name, options.no_host_dns)/s/)/, local_hostname=False)/' /usr/lib/python3.6/site-packages/ipaserver/install/server/replicainstall.py && python3 -m compileall /usr/lib/python3.6/site-packages/ipaserver/install/server/replicainstall.py
 # Workaround https://fedorahosted.org/spin-kickstarts/ticket/60
 RUN [ -L /etc/systemd/system/syslog.service ] && ! [ -f /etc/systemd/system/syslog.service ] && rm -f /etc/systemd/system/syslog.service
+# Workaround https://github.com/freeipa/freeipa-container/issues/187
+COPY certmonger-wait-for-ready.conf /usr/lib/systemd/system/certmonger.service.d/wait-for-ready.conf
 
 RUN find /etc/systemd/system/* '!' -name '*.wants' | xargs rm -rvf
 RUN for i in basic.target network.service netconsole.service ; do rm -f /usr/lib/systemd/system/$i && ln -s /dev/null /usr/lib/systemd/system/$i ; done

--- a/Dockerfile.fedora-rawhide
+++ b/Dockerfile.fedora-rawhide
@@ -12,6 +12,8 @@ RUN dnf upgrade -y && dnf install -y freeipa-server freeipa-server-dns freeipa-s
 RUN sed -i '/installutils.verify_fqdn(config.master_host_name, options.no_host_dns)/s/)/, local_hostname=False)/' /usr/lib/python3.*/site-packages/ipaserver/install/server/replicainstall.py && python3 -m compileall /usr/lib/python3.*/site-packages/ipaserver/install/server/replicainstall.py
 # Workaround https://fedorahosted.org/spin-kickstarts/ticket/60
 RUN [ -L /etc/systemd/system/syslog.service ] && ! [ -f /etc/systemd/system/syslog.service ] && rm -f /etc/systemd/system/syslog.service
+# Workaround https://github.com/freeipa/freeipa-container/issues/187
+COPY certmonger-wait-for-ready.conf /usr/lib/systemd/system/certmonger.service.d/wait-for-ready.conf
 
 RUN find /etc/systemd/system/* '!' -name '*.wants' | xargs rm -rvf
 RUN for i in basic.target network.service netconsole.service ; do rm -f /usr/lib/systemd/system/$i && ln -s /dev/null /usr/lib/systemd/system/$i ; done

--- a/certmonger-wait-for-ready.conf
+++ b/certmonger-wait-for-ready.conf
@@ -1,0 +1,2 @@
+[Service]
+ExecStartPost=/bin/bash -c 'while ! dbus-send --system --type=method_call --print-reply --dest=org.fedorahosted.certmonger /org/fedorahosted/certmonger org.freedesktop.DBus.Introspectable.Introspect > /dev/null ; do sleep 5 ; done'

--- a/init-data
+++ b/init-data
@@ -165,7 +165,10 @@ fi
 DATA_TEMPLATE=/data-template
 
 if ! [ -f /etc/ipa/ca.crt ] ; then
-	( cd $DATA_TEMPLATE && tar cf - . ) | ( cd $DATA && tar xf - )
+	if ! [ -f $DATA/ipa.csr ] ; then
+		# Do not refresh $DATA in the second stage of the external CA setup
+		( cd $DATA_TEMPLATE && tar cf - . ) | ( cd $DATA && tar xf - )
+	fi
 	if [ -n "$PASSWORD" ] ; then
 		if [ "$COMMAND" == 'ipa-server-install' ] ; then
 			printf '%q\n' "--admin-password=$PASSWORD" >> $OPTIONS_FILE

--- a/tests/build-and-run.sh
+++ b/tests/build-and-run.sh
@@ -9,8 +9,10 @@ if ! grep -F "Dockerfile.$dockerfile" <( echo "$BUILD_DOCKERFILES" ) ; then
 fi
 
 docker build -t local/freeipa-server -f Dockerfile.$dockerfile .
+mkdir data
 docker run $privileged -h ipa.example.test \
 	--sysctl net.ipv6.conf.all.disable_ipv6=0 \
 	--tmpfs /run --tmpfs /tmp -v /dev/urandom:/dev/random:ro -v /sys/fs/cgroup:/sys/fs/cgroup:ro \
+	-v $(pwd)/data:/data \
 	-e PASSWORD=Secret123 local/freeipa-server \
 	exit-on-finished -U -r EXAMPLE.TEST --setup-dns --no-forwarders --no-ntp

--- a/tests/build-and-run.sh
+++ b/tests/build-and-run.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -e
+set -x
+
+if ! grep -F "Dockerfile.$dockerfile" <( echo "$BUILD_DOCKERFILES" ) ; then
+	echo "Skipping, Dockerfile.$dockerfile not modified."
+	exit
+fi
+
+docker build -t local/freeipa-server -f Dockerfile.$dockerfile .
+docker run $privileged -h ipa.example.test \
+	--sysctl net.ipv6.conf.all.disable_ipv6=0 \
+	--tmpfs /run --tmpfs /tmp -v /dev/urandom:/dev/random:ro -v /sys/fs/cgroup:/sys/fs/cgroup:ro \
+	-e PASSWORD=Secret123 local/freeipa-server \
+	exit-on-finished -U -r EXAMPLE.TEST --setup-dns --no-forwarders --no-ntp

--- a/tests/build-and-run.sh
+++ b/tests/build-and-run.sh
@@ -15,4 +15,14 @@ docker run $privileged -h ipa.example.test \
 	--tmpfs /run --tmpfs /tmp -v /dev/urandom:/dev/random:ro -v /sys/fs/cgroup:/sys/fs/cgroup:ro \
 	-v $(pwd)/data:/data \
 	-e PASSWORD=Secret123 local/freeipa-server \
-	exit-on-finished -U -r EXAMPLE.TEST --setup-dns --no-forwarders --no-ntp
+	exit-on-finished -U -r EXAMPLE.TEST --setup-dns --no-forwarders --no-ntp $ca
+if [ -n "$ca" ] ; then
+	sudo tests/generate-external-ca.sh data
+	docker run $privileged -h ipa.example.test \
+		--sysctl net.ipv6.conf.all.disable_ipv6=0 \
+		--tmpfs /run --tmpfs /tmp -v /dev/urandom:/dev/random:ro -v /sys/fs/cgroup:/sys/fs/cgroup:ro \
+		-v $(pwd)/data:/data \
+		-e PASSWORD=Secret123 local/freeipa-server \
+		exit-on-finished -U -r EXAMPLE.TEST --setup-dns --no-forwarders --no-ntp \
+			--external-cert-file=/data/ipa.crt --external-cert-file=/data/ca.crt
+fi

--- a/tests/generate-external-ca.sh
+++ b/tests/generate-external-ca.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e
+set -x
+
+DATA="$1"
+NSSDB=/tmp/nssdb-$RANDOM
+mkdir -p $NSSDB
+rm -rf $NSSDB/*
+certutil -N -d $NSSDB --empty-password
+echo -e "y\n\n\n$RANDOM\n\n" | certutil -S -n "IPA ROOTCA certificate" -s "cn=CAcert" -x -t "CT,," -m 1000 -v 120 -d $NSSDB -z /etc/hostname -2 --keyUsage=certSigning --extSKID
+certutil -L -d $NSSDB -n 'IPA ROOTCA certificate' -a > "$DATA"/ca.crt
+echo -e "$RANDOM\nn\n" | certutil -C -m 2346 -i "$DATA"/ipa.csr -o "$DATA"/ipa.crt -c 'IPA ROOTCA certificate' -d $NSSDB -a --extSKID


### PR DESCRIPTION
Addressing
```
Failed to start Directory Service: Command '/bin/systemctl start dirsrv@EXAMPLE-TEST.service' returned non-zero exit status 1
```

This fixes `--external-ca` setup on CentOS 7 and RHEL 7 and (with other fix) on Fedora 27+.

KDC is now setup in the first stage and we need to preserve `krb5.conf` to have the realm configured, for `dirsrv@` to start properly.