### PR TITLE
The ipaplatform was refactored on Fedora 27, just decide about the platform ourselves.

### DIFF
--- a/ipa-server-configure-first
+++ b/ipa-server-configure-first
@@ -100,7 +100,10 @@ function upgrade_server () {
 	rm -rf $DIR
 	systemctl start certmonger.service
 	if [ -f /var/lib/ipa/sysupgrade/sysupgrade.state ] ; then
-		PLATFORM=$(python -c 'import ipaplatform; print ipaplatform.NAME;')
+		PLATFORM=rhel
+		if rpm -q freeipa-server > /dev/null 2>&1 ; then
+			PLATFORM=fedora
+		fi
 		sed -i "s/platform.*/platform = $PLATFORM/" /var/lib/ipa/sysupgrade/sysupgrade.state
 	fi
 	ipa-server-upgrade

--- a/tests/build-and-run.sh
+++ b/tests/build-and-run.sh
@@ -8,8 +8,10 @@ if ! grep -F "Dockerfile.$dockerfile" <( echo "$BUILD_DOCKERFILES" ) ; then
 	exit
 fi
 
+date
 docker build -t local/freeipa-server -f Dockerfile.$dockerfile .
 mkdir data
+date
 docker run $privileged -h ipa.example.test \
 	--sysctl net.ipv6.conf.all.disable_ipv6=0 \
 	--tmpfs /run --tmpfs /tmp -v /dev/urandom:/dev/random:ro -v /sys/fs/cgroup:/sys/fs/cgroup:ro \
@@ -17,7 +19,9 @@ docker run $privileged -h ipa.example.test \
 	-e PASSWORD=Secret123 local/freeipa-server \
 	exit-on-finished -U -r EXAMPLE.TEST --setup-dns --no-forwarders --no-ntp $ca
 if [ -n "$ca" ] ; then
+	date
 	sudo tests/generate-external-ca.sh data
+	date
 	docker run $privileged -h ipa.example.test \
 		--sysctl net.ipv6.conf.all.disable_ipv6=0 \
 		--tmpfs /run --tmpfs /tmp -v /dev/urandom:/dev/random:ro -v /sys/fs/cgroup:/sys/fs/cgroup:ro \
@@ -26,3 +30,21 @@ if [ -n "$ca" ] ; then
 		exit-on-finished -U -r EXAMPLE.TEST --setup-dns --no-forwarders --no-ntp \
 			--external-cert-file=/data/ipa.crt --external-cert-file=/data/ca.crt
 fi
+date
+docker run $privileged -h ipa.example.test \
+	--sysctl net.ipv6.conf.all.disable_ipv6=0 \
+	--tmpfs /run --tmpfs /tmp -v /dev/urandom:/dev/random:ro -v /sys/fs/cgroup:/sys/fs/cgroup:ro \
+	-v $(pwd)/data:/data \
+	local/freeipa-server \
+	exit-on-finished
+date
+echo "RUN uuidgen > /data-template/build-id" >> Dockerfile.$dockerfile
+echo data >> .dockerignore
+docker build -t local/freeipa-server -f Dockerfile.$dockerfile .
+date
+docker run $privileged -h ipa.example.test \
+	--sysctl net.ipv6.conf.all.disable_ipv6=0 \
+	--tmpfs /run --tmpfs /tmp -v /dev/urandom:/dev/random:ro -v /sys/fs/cgroup:/sys/fs/cgroup:ro \
+	-v $(pwd)/data:/data \
+	local/freeipa-server \
+	exit-on-finished


### PR DESCRIPTION
Fixes https://github.com/freeipa/freeipa-container/issues/214.