### PR TITLE
Workaround 1606541, skip tests on rawhide.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,6 @@ matrix:
     - stage: sanity
       script: if comm -23 <( echo "$FILES_CHANGED" ) <( echo "$TRAVIS_DOCKERFILES" ) | grep Dockerfile. ; then echo "Dockerfile modified but not tracked by Travis." >&2 ; exit 1 ; else echo "No unexpected Dockerfile changes, OK." ; fi
     - stage: build
-      env: dockerfile=fedora-rawhide
-    - stage: build
       env: dockerfile=fedora-28 privileged=--privileged
     - stage: build
       env: dockerfile=fedora-28 ca=--external-ca privileged=--privileged
@@ -45,6 +43,8 @@ matrix:
     - stage: build
       env: dockerfile=centos-7 ca=--external-ca
   exclude:
+    - stage: build
+      env: dockerfile=fedora-rawhide
     - stage: build
       env: dockerfile=fedora-25
     - stage: build


### PR DESCRIPTION
Avoiding
```
  [1/44]: creating directory server instance
  [error] FileNotFoundError: [Errno 2] No such file or directory: '/usr/sbin/setup-ds.pl': '/usr/sbin/setup-ds.pl'
FreeIPA server configuration failed.
```
and
```
 [error] RuntimeError: failed to create DS instance CalledProcessError(Command ['/usr/sbin/setup-ds.pl', '--silent', '--logfile', '-', '-f', '/tmp/tmpls_vesa4'] returned non-zero exit status 1: '')
FreeIPA server configuration failed.
```