### PR TITLE
[WIP, do not merge] Massive amount of changes to make FreeIPA container runnable as --read-only.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,17 +30,21 @@ matrix:
     - stage: sanity
       script: if comm -23 <( echo "$FILES_CHANGED" ) <( echo "$TRAVIS_DOCKERFILES" ) | grep Dockerfile. ; then echo "Dockerfile modified but not tracked by Travis." >&2 ; exit 1 ; else echo "No unexpected Dockerfile changes, OK." ; fi
     - stage: build
-      env: dockerfile=fedora-29
+      env: dockerfile=fedora-29 readonly=--read-only
     - stage: build
-      env: dockerfile=fedora-29 ca=--external-ca
+      env: dockerfile=fedora-29 ca=--external-ca readonly=--read-only
+    - stage: build
+      env: dockerfile=fedora-29
     - stage: build
       env: dockerfile=fedora-28
     - stage: build
       env: dockerfile=fedora-27
     - stage: build
-      env: dockerfile=centos-7
+      env: dockerfile=centos-7 readonly=--read-only
     - stage: build
-      env: dockerfile=centos-7 ca=--external-ca
+      env: dockerfile=centos-7 ca=--external-ca readonly=--read-only
+    - stage: build
+      env: dockerfile=centos-7
     - stage: build
       env: dockerfile=fedora-rawhide
     - stage: build
@@ -50,7 +54,7 @@ matrix:
     - stage: build
       env: dockerfile=fedora-24 replica=none seccomp=unconfined
     - stage: build
-      env: dockerfile=fedora-23 replica=none seccomp=unconfined
+      env: dockerfile=fedora-23 replica=none seccomp=unconfined readonly=--read-only
   exclude:
     - stage: build
       env: dockerfile=rhel-7

--- a/README
+++ b/README
@@ -29,13 +29,26 @@ On SELinux enabled systems,
 
 might be needed to enable running systemd in the containers.
 
-You then run the container with
+On systems where oci-systemd-hook is available on the host, the
+FreeIPA server container can be created with
+
+    docker run --name freeipa-server-container -ti \
+       -h ipa.example.test \
+       --read-only \
+       -v /var/lib/ipa-data:/data:Z freeipa-server [ opts ]
+
+Without oci-systemd-hook, `/run`, `/tmp`, and `/sys/fs/cgroup`
+need to be mounted explicitly:
 
     docker run --name freeipa-server-container -ti \
        -h ipa.example.test \
        -v /sys/fs/cgroup:/sys/fs/cgroup:ro \
        --tmpfs /run --tmpfs /tmp \
        -v /var/lib/ipa-data:/data:Z freeipa-server [ opts ]
+
+Also, without oci-systemd-hook, running the container as
+`--read-only` will typically only work when `/etc/machine-id`
+is pre-created on the host and bind-mounted to the container with `-v`.
 
 The list of options [opts] can start with exit-on-finished to stop
 the container after successfully configuring the server in the container
@@ -47,7 +60,7 @@ the server. The `docker run` invocation also accepts command line
 parameters that will be passed to `ipa-server-install`, so
 unattended invocation is possible, for example with
 
-    docker run --rm -e PASSWORD=Secret123 -h ipa.example.test \
+    docker run --rm -e PASSWORD=Secret123 -h ipa.example.test --read-only \
         freeipa-server exit-on-finished -U -r EXAMPLE.TEST --no-ntp
 
 Optionally, you can put into the directory mounted into /data

--- a/ipa-server-configure-first
+++ b/ipa-server-configure-first
@@ -105,7 +105,7 @@ if [ "$1" == upgrade ] ; then
 		echo "The /data volume was created using incompatible image." >&2
 		exit 2
 	fi
-	if [ -f /data/etc/resolv.conf.ipa ] ; then
+	if [ -f /data/etc/resolv.conf.ipa ] && ! grep '^nameserver 127\.0\.0\.1$' /etc/resolv.conf ; then
 		perl -pe 's/^(nameserver).*/$1 127.0.0.1/' /data/etc/resolv.conf.ipa > /etc/resolv.conf
 		if ! grep -q "\b$HOSTNAME\b" /etc/hosts ; then
 			echo "127.0.0.2 $HOSTNAME" >> /etc/hosts

--- a/tests/run-master-and-replica.sh
+++ b/tests/run-master-and-replica.sh
@@ -71,7 +71,7 @@ function run_ipa_container() {
 	fi
 	(
 	set -x
-	docker run -d --name "$N" -h $HOSTNAME \
+	docker run $readonly -d --name "$N" -h $HOSTNAME \
 		$SEC_OPTS --sysctl net.ipv6.conf.all.disable_ipv6=0 \
 		--tmpfs /run --tmpfs /tmp -v /dev/urandom:/dev/random:ro -v /sys/fs/cgroup:/sys/fs/cgroup:ro \
 		-v $VOLUME:/data:Z $DOCKER_RUN_OPTS \

--- a/tests/run-master-and-replica.sh
+++ b/tests/run-master-and-replica.sh
@@ -69,12 +69,22 @@ function run_ipa_container() {
 	if [ -n "$seccomp" ] ; then
 		SEC_OPTS="--security-opt=seccomp:$seccomp"
 	fi
+	VOLUME_OPTS=
+	if [ -n "$readonly" -a -n "$TRAVIS" ] ; then
+		if ! [ -f $VOLUME/etc/machine-id ] ; then
+			mkdir -p $VOLUME/etc
+			chmod o+rx $VOLUME/etc
+			uuidgen | sed 's/-//g' > $VOLUME/etc/machine-id
+			chmod 444 $VOLUME/etc/machine-id
+		fi
+		VOLUME_OPTS="-v $VOLUME/etc/machine-id:/etc/machine-id:ro,Z"
+	fi
 	(
 	set -x
 	docker run $readonly -d --name "$N" -h $HOSTNAME \
 		$SEC_OPTS --sysctl net.ipv6.conf.all.disable_ipv6=0 \
 		--tmpfs /run --tmpfs /tmp -v /dev/urandom:/dev/random:ro -v /sys/fs/cgroup:/sys/fs/cgroup:ro \
-		-v $VOLUME:/data:Z $DOCKER_RUN_OPTS \
+		-v $VOLUME:/data:Z $VOLUME_OPTS $DOCKER_RUN_OPTS \
 		-e PASSWORD=Secret123 "$IMAGE" "$@"
 	)
 	wait_for_ipa_container "$N" "$@"

--- a/tests/run-master-and-replica.sh
+++ b/tests/run-master-and-replica.sh
@@ -82,6 +82,10 @@ function run_ipa_container() {
 
 IMAGE="$1"
 
+if [ "$readonly" == "--read-only" ] ; then
+	readonly="$readonly --dns=127.0.0.1"
+fi
+
 # Initial setup of the FreeIPA server
 run_ipa_container $IMAGE freeipa-master exit-on-finished -U -r EXAMPLE.TEST --setup-dns --no-forwarders --no-ntp $ca
 


### PR DESCRIPTION
The goal was to avoid writing to overlay and they copying the changes to `/data`. We monkey-patch in build time paths that the software uses to make it work with `/data` directly.