### PR TITLE
 The /etc/named.conf is symlink to /data, avoid changing it.

### DIFF
--- a/init-data
+++ b/init-data
@@ -242,6 +242,7 @@ if [ -f "$DATA/build-id" ] ; then
 				chmod --reference=$DATA_TEMPLATE$i $DATA$i
 			fi
 		done
+		SYSTEMD_OPTS=--unit=ipa-server-upgrade.service
 	fi
 	if [ -f /etc/ipa/ca.crt ] ; then
 		rm -f "$DATA/etc/systemd/system/multi-user.target.wants/ipa-server-configure-first.service"
@@ -267,6 +268,6 @@ if [ -n "$IPA_SERVER_IP" ] ; then
 	echo "$IPA_SERVER_IP" > /run/ipa/ipa-server-ip
 fi
 
-exec /usr/sbin/init --show-status=false
+exec /usr/sbin/init --show-status=false $SYSTEMD_OPTS
 
 exit 10

--- a/ipa-server-configure-first
+++ b/ipa-server-configure-first
@@ -91,7 +91,7 @@ function upgrade_server () {
 	for i in 389-ds-base pki-server bind-dyndb-ldap ; do
 		rpm -q --scripts $i | perl -lne '/^\S+ scriptlet/ and $x = 0; print if $x; if (/^postinstall scriptlet \(using (\S+)\)/) { $x = 1; print "#!$1"; if ($1 eq "/bin/sh") { print "set -x" } }' > $DIR/$i.script
 		if [ -s "$DIR/$i.script" ] ; then
-			sed -i '\|/sbin/ldconfig|d' $DIR/$i.script
+			sed -i '\|/sbin/ldconfig|d;s%/etc/named.conf%/data/etc/named.conf%' $DIR/$i.script
 			chmod a+x $DIR/$i.script
 			$DIR/$i.script 2
 		fi

--- a/ipa-server-configure-first
+++ b/ipa-server-configure-first
@@ -85,7 +85,6 @@ exec >> /var/log/ipa-server-configure-first.log 2>&1
 echo "$(date) $0 $@"
 
 function upgrade_server () {
-	systemctl stop dirsrv.target
 	/usr/sbin/setup-ds.pl -u -s General.UpdateMode=offline
 	DIR=/var/libexec/ipa/ipa-upgrade-rpm-scriptlets.$$
 	mkdir -p $DIR
@@ -98,7 +97,6 @@ function upgrade_server () {
 		fi
 	done
 	rm -rf $DIR
-	systemctl start certmonger.service
 	if [ -f /var/lib/ipa/sysupgrade/sysupgrade.state ] ; then
 		PLATFORM=rhel
 		if rpm -q freeipa-server > /dev/null 2>&1 ; then
@@ -109,6 +107,7 @@ function upgrade_server () {
 	ipa-server-upgrade
 	mv /data/build-id /data/build-id-upgraded-$( date +'%Y%m%d-%H%M%S' )
 	cp -f /data-template/build-id /data/build-id
+	systemctl default
 }
 
 if [ "$1" == upgrade ] ; then

--- a/ipa-server-upgrade.service
+++ b/ipa-server-upgrade.service
@@ -1,6 +1,8 @@
 [Unit]
 Description=Upgrade IPA server upon subsequent runs
 Before=ipa.service
+Requires=systemd-tmpfiles-setup.service systemd-journald.service dbus.service
+After=systemd-tmpfiles-setup.service systemd-journald.service dbus.service
 
 [Service]
 Type=oneshot

--- a/ipa-server-upgrade.service
+++ b/ipa-server-upgrade.service
@@ -3,6 +3,7 @@ Description=Upgrade IPA server upon subsequent runs
 Before=ipa.service
 Requires=systemd-tmpfiles-setup.service systemd-journald.service dbus.service
 After=systemd-tmpfiles-setup.service systemd-journald.service dbus.service
+AllowIsolate=yes
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
Upgrading to Fedora 26 or newer, `sed -i.bak` on `/etc/named.conf` from rpm scriptlets would modify the symlink, not the underlying file on `/data`, and produce
```
C /etc/named.conf
C /etc/named.conf.bak
```
`docker diff` output.