### PR TITLE
Updated openshift template to support adding replicas

### DIFF
--- a/freeipa-server-openshift.json
+++ b/freeipa-server-openshift.json
@@ -42,8 +42,8 @@
             "metadata": {
                 "name": "${IPA_SERVER_SERVICE}-password"
             },
-            "stringData" : {
-                "admin.password" : "${IPA_ADMIN_PASSWORD}"
+            "stringData": {
+                "admin.password": "${IPA_ADMIN_PASSWORD}"
             }
         },
         {
@@ -218,6 +218,33 @@
                                 "emptyDir": {}
                             }
                         ],
+                        "initContainers": [
+                            {
+                                "name": "init-freeipa",
+                                "image": "busybox",
+                                "command": [
+                                    "sh",
+                                    "-c",
+                                    "if [[ \"${IPA_INSTALL_COMMAND}\" = 'ipa-replica-install' ]]; then echo \"${IPA_SERVER_INSTALL_OPTS}\" > /data/ipa-replica-install-options; else echo \"${IPA_SERVER_INSTALL_OPTS}\" > /data/ipa-server-install-options; fi"
+                                ],
+                                "env": [
+                                    {
+                                        "name": "IPA_INSTALL_COMMAND",
+                                        "value": "${IPA_INSTALL_COMMAND}"
+                                    },
+                                    {
+                                        "name": "IPA_SERVER_INSTALL_OPTS",
+                                        "value": "${IPA_SERVER_INSTALL_OPTS}"
+                                    }
+                                ],
+                                "volumeMounts": [
+                                    {
+                                        "name": "${IPA_SERVER_SERVICE}-data",
+                                        "mountPath": "/data"
+                                    }
+                                ]
+                            }
+                        ],
                         "containers": [
                             {
                                 "name": "${IPA_SERVER_SERVICE}",
@@ -294,15 +321,11 @@
                                         "value": "${IPA_SERVER_IP}"
                                     },
                                     {
-                                        "name": "IPA_SERVER_INSTALL_OPTS",
-                                        "value": "${IPA_SERVER_INSTALL_OPTS}"
-                                    },
-                                    {
                                         "name": "PASSWORD",
                                         "valueFrom": {
-                                            "secretKeyRef" : {
-                                                "name" : "${IPA_SERVER_SERVICE}-password",
-                                                "key" : "admin.password"
+                                            "secretKeyRef": {
+                                                "name": "${IPA_SERVER_SERVICE}-password",
+                                                "key": "admin.password"
                                             }
                                         }
                                     }
@@ -401,6 +424,12 @@
             "required": false,
             "from": "[a-zA-Z0-9]{32}",
             "generate": "expression"
+        },
+        {
+            "name": "IPA_INSTALL_COMMAND",
+            "displayName": "Set this to ipa-replica-install if a replica install is required",
+            "required": false,
+            "value": "ipa-server-install"
         },
         {
             "name": "SERVICE_ACCOUNT_USEROOT",


### PR DESCRIPTION
Referencing this:
https://github.com/freeipa/freeipa-container/issues/139

And this:
https://github.com/freeipa/freeipa-container/pull/260

I've changed it back to a deploymentconfig instead of the statefulset that I used in my first attempt so you need to create the first server and the replicas separately, but the extra bits are there so that replicas can be created too. It requires the domain you use to be resolvable via DNS so that the replicas can resolve the first instance when they are added. I did this by setting dnsmasq on the openshift nodes to forward to the IPs of the freeipa services ($IPA_SERVER_IP) for the domain that I used, ie doing the following on each of the nodes:

```
# echo -e "server=/ipa.example.com/172.30.10.10\nserver=/ipa.example.com/172.30.10.11" > /etc/dnsmasq.d/freeipa-forward.conf
# systemctl restart dnsmasq
```

To install the first instance, I used the following command:

```
oc new-app --name freeipa-server -f freeipa-server-openshift.yaml -p IPA_SERVER_SERVICE=freeipa-a -p IPA_SERVER_IMAGE=freeipa-server:centos-7 -p IPA_SERVER_HOSTNAME=freeipa-a.ipa.example.com -p IPA_ADMIN_PASSWORD=Secret123 -p TIMEOUT=1200 -p IPA_SERVER_IP=172.30.10.10 -p IPA_SERVER_INSTALL_OPTS="-U -n ipa.example.com -r IPA.EXAMPLE.COM --setup-dns --no-forwarders"
```

And to install the replica, I used this:

```
oc new-app --name freeipa-server -f freeipa-server-openshift.yaml -p IPA_SERVER_SERVICE=freeipa-b -p IPA_SERVER_IMAGE=freeipa-server:centos-7 -p IPA_SERVER_HOSTNAME=freeipa-b.ipa.example.com -p IPA_ADMIN_PASSWORD=Secret123 -p TIMEOUT=1200 -p IPA_SERVER_IP=172.30.10.11 -p IPA_SERVER_INSTALL_OPTS="--principal=admin --no-host-dns --setup-ca --setup-dns --no-forwarders" -p IPA_INSTALL_COMMAND=ipa-replica-install
```