### PR TITLE
Update for RHEL 7.7

### DIFF
--- a/Dockerfile.rhel-7
+++ b/Dockerfile.rhel-7
@@ -5,7 +5,6 @@ MAINTAINER FreeIPA Developers <freeipa-devel@lists.fedorahosted.org>
 # Moving groupadd before freeipa installation to ensure uid and guid will be same
 RUN groupadd -g 288 kdcproxy ; useradd -u 288 -g 288 -c 'IPA KDC Proxy User' -d '/var/lib/kdcproxy' -s '/sbin/nologin' kdcproxy
 RUN groupadd -g 289 ipaapi; useradd -u 289 -g 289 -c 'IPA Framework User' -r -d / -s '/sbin/nologin' ipaapi
-RUN groupadd -g 389 dirsrv ; useradd -u 389 -g 389 -c 'user for 389-ds-base' -r -d '/usr/share/dirsrv' -s '/sbin/nologin' dirsrv
 
 # Workaround 1615948
 RUN ln -s /bin/false /usr/sbin/systemd-machine-id-setup
@@ -17,9 +16,6 @@ RUN yum install --disablerepo='*' --enablerepo=rhel-7-server-rpms -y ipa-server 
 # debug: RUN test "$container" = oci
 ENTRYPOINT [ "/usr/sbin/init" ]
 STOPSIGNAL RTMIN+3
-# Workaround 1373833
-COPY patches/basic-centos-7.patch /root
-RUN patch --verbose -p0 --fuzz=0 < /root/basic-centos-7.patch
 # test-addon: VOLUME [ "/var/log/journal" ]
 # test: systemd-container-failed.sh network.service TRAVIS:sys-fs-fuse-connections.mount var-lib-nfs-rpc_pipefs.mount
 


### PR DESCRIPTION
Edit: The workaround to create 389 user is no longer needed,
removing from the Dockerfile.rhel-7

With updated RHEL 7.7 we are unable to patch file
tmpfiles.d/opencryptoki.conf so removing
basic-centos-7.patch from Dockerfile.rhel-7.

Refreshing ipa-rhel-7.patch for kernel_keyring.py
in ipa-rhel-7.patch due to changes in IPA.