### PR TITLE
Workaround 1656519 - set the ulimit in the container to reasonably low value.

### DIFF
--- a/Dockerfile.centos-7
+++ b/Dockerfile.centos-7
@@ -17,6 +17,10 @@ RUN yum install -y ipa-server ipa-server-dns ipa-server-trust-ad patch && yum cl
 # debug: RUN test -f /etc/machine-id && ! test -s /etc/machine-id
 # debug: RUN test -z "$container"
 ENV container oci
+
+# Establish reasonably low open files limit in the container
+RUN echo "DefaultLimitNOFILE=1024" >> /etc/systemd/system.conf
+
 ENTRYPOINT [ "/usr/sbin/init" ]
 STOPSIGNAL RTMIN+3
 # Workaround 1373833

--- a/Dockerfile.fedora-23
+++ b/Dockerfile.fedora-23
@@ -15,6 +15,10 @@ RUN groupadd -g 288 kdcproxy ; useradd -u 288 -g 288 -c 'IPA KDC Proxy User' -d 
 # debug: RUN ! test -f /etc/machine-id
 # debug: RUN test -z "$container"
 ENV container oci
+
+# Establish reasonably low open files limit in the container
+RUN echo "DefaultLimitNOFILE=1024" >> /etc/systemd/system.conf
+
 ENTRYPOINT [ "/usr/sbin/init" ]
 STOPSIGNAL RTMIN+3
 # debug: RUN systemctl mask dnf-makecache.service

--- a/Dockerfile.fedora-24
+++ b/Dockerfile.fedora-24
@@ -14,6 +14,10 @@ RUN groupadd -g 288 kdcproxy ; useradd -u 288 -g 288 -c 'IPA KDC Proxy User' -d 
 # debug: RUN ! test -f /etc/machine-id
 # debug: RUN test -z "$container"
 ENV container oci
+
+# Establish reasonably low open files limit in the container
+RUN echo "DefaultLimitNOFILE=1024" >> /etc/systemd/system.conf
+
 ENTRYPOINT [ "/usr/sbin/init" ]
 STOPSIGNAL RTMIN+3
 # test-addon: VOLUME [ "/var/log/journal" ]

--- a/Dockerfile.fedora-25
+++ b/Dockerfile.fedora-25
@@ -13,6 +13,10 @@ RUN groupadd -g 288 kdcproxy ; useradd -u 288 -g 288 -c 'IPA KDC Proxy User' -d 
 RUN echo -n > /etc/machine-id
 # debug: RUN test -z "$container"
 ENV container oci
+
+# Establish reasonably low open files limit in the container
+RUN echo "DefaultLimitNOFILE=1024" >> /etc/systemd/system.conf
+
 ENTRYPOINT [ "/usr/sbin/init" ]
 STOPSIGNAL RTMIN+3
 # test-addon: VOLUME [ "/var/log/journal" ]

--- a/Dockerfile.fedora-26
+++ b/Dockerfile.fedora-26
@@ -13,6 +13,10 @@ RUN groupadd -g 288 kdcproxy ; useradd -u 288 -g 288 -c 'IPA KDC Proxy User' -d 
 # debug: RUN test -f /etc/machine-id && ! test -s /etc/machine-id
 # debug: RUN test -z "$container"
 ENV container oci
+
+# Establish reasonably low open files limit in the container
+RUN echo "DefaultLimitNOFILE=1024" >> /etc/systemd/system.conf
+
 ENTRYPOINT [ "/usr/sbin/init" ]
 STOPSIGNAL RTMIN+3
 # test-addon: VOLUME [ "/var/log/journal" ]

--- a/Dockerfile.fedora-27
+++ b/Dockerfile.fedora-27
@@ -16,6 +16,10 @@ RUN dnf upgrade -y --setopt=install_weak_deps=False \
 # debug: RUN test -f /etc/machine-id && ! test -s /etc/machine-id
 # debug: RUN test -z "$container"
 ENV container oci
+
+# Establish reasonably low open files limit in the container
+RUN echo "DefaultLimitNOFILE=1024" >> /etc/systemd/system.conf
+
 ENTRYPOINT [ "/usr/sbin/init" ]
 STOPSIGNAL RTMIN+3
 # test-addon: VOLUME [ "/var/log/journal" ]
@@ -44,9 +48,6 @@ ADD hostnamectl-wrapper /usr/bin/domainname
 
 COPY patches/ipa-fedora-27.patch /root
 RUN set -o pipefail ; patch --verbose -p0 --fuzz=0 < /root/ipa-fedora-27.patch | tee /dev/stderr | sed -n 's/^patching file //;T;/\.py$/p' | xargs python3 -m compileall
-
-# Workaround https://github.com/freeipa/freeipa-container/issues/187
-COPY certmonger-wait-for-ready.conf /usr/lib/systemd/system/certmonger.service.d/wait-for-ready.conf
 
 RUN mv /usr/sbin/ipa-join /usr/sbin/ipa-join.orig
 COPY ipa-join /usr/sbin/ipa-join

--- a/Dockerfile.fedora-28
+++ b/Dockerfile.fedora-28
@@ -21,6 +21,10 @@ RUN rm -f /etc/crypto-policies/local.d/nss-p11-kit.config && update-crypto-polic
 # debug: RUN test -f /etc/machine-id && ! test -s /etc/machine-id
 # debug: RUN test -z "$container"
 ENV container oci
+
+# Establish reasonably low open files limit in the container
+RUN echo "DefaultLimitNOFILE=1024" >> /etc/systemd/system.conf
+
 ENTRYPOINT [ "/usr/sbin/init" ]
 STOPSIGNAL RTMIN+3
 # test-addon: VOLUME [ "/var/log/journal" ]
@@ -50,8 +54,6 @@ ADD hostnamectl-wrapper /usr/bin/domainname
 COPY patches/ipa-fedora-28.patch /root
 RUN set -o pipefail ; patch --verbose -p0 --fuzz=0 < /root/ipa-fedora-28.patch | tee /dev/stderr | sed -n 's/^patching file //;T;/\.py$/p' | xargs python3 -m compileall
 
-# Workaround https://github.com/freeipa/freeipa-container/issues/187
-COPY certmonger-wait-for-ready.conf /usr/lib/systemd/system/certmonger.service.d/wait-for-ready.conf
 # test-addon: VOLUME [ "/var/log/journal" ]
 ## # test: systemd-container-ipa-server-install.sh
 

--- a/Dockerfile.fedora-29
+++ b/Dockerfile.fedora-29
@@ -17,6 +17,10 @@ RUN dnf install -y --setopt=install_weak_deps=False freeipa-server freeipa-serve
 # debug: RUN test -f /etc/machine-id && ! test -s /etc/machine-id
 # debug: RUN test -z "$container"
 ENV container oci
+
+# Establish reasonably low open files limit in the container
+RUN echo "DefaultLimitNOFILE=1024" >> /etc/systemd/system.conf
+
 ENTRYPOINT [ "/usr/sbin/init" ]
 STOPSIGNAL RTMIN+3
 # test-addon: VOLUME [ "/var/log/journal" ]
@@ -47,8 +51,6 @@ ADD hostnamectl-wrapper /usr/bin/nisdomainname
 COPY patches/ipa-fedora-29.patch /root
 RUN set -o pipefail ; patch --verbose -p0 --fuzz=0 < /root/ipa-fedora-29.patch | tee /dev/stderr | sed -n 's/^patching file //;T;/\.py$/p' | xargs python3 -m compileall
 
-# Workaround https://github.com/freeipa/freeipa-container/issues/187
-COPY certmonger-wait-for-ready.conf /usr/lib/systemd/system/certmonger.service.d/wait-for-ready.conf
 # test-addon: VOLUME [ "/var/log/journal" ]
 ## # test: systemd-container-ipa-server-install.sh
 

--- a/Dockerfile.fedora-30
+++ b/Dockerfile.fedora-30
@@ -20,6 +20,10 @@ RUN systemctl mask rpc-gssd.service
 # Container image which runs systemd
 # debug: RUN test -f /etc/machine-id && ! test -s /etc/machine-id
 # debug: RUN test "$container" = oci
+
+# Establish reasonably low open files limit in the container
+RUN echo "DefaultLimitNOFILE=1024" >> /etc/systemd/system.conf
+
 ENTRYPOINT [ "/usr/sbin/init" ]
 STOPSIGNAL RTMIN+3
 # test-addon: VOLUME [ "/var/log/journal" ]
@@ -50,8 +54,6 @@ ADD hostnamectl-wrapper /usr/bin/nisdomainname
 COPY patches/ipa-fedora-30.patch /root
 RUN set -o pipefail ; patch --verbose -p0 --fuzz=0 < /root/ipa-fedora-30.patch | tee /dev/stderr | sed -n 's/^patching file //;T;/\.py$/p' | xargs python3 -m compileall
 
-# Workaround https://github.com/freeipa/freeipa-container/issues/187
-COPY certmonger-wait-for-ready.conf /usr/lib/systemd/system/certmonger.service.d/wait-for-ready.conf
 # test-addon: VOLUME [ "/var/log/journal" ]
 ## # test: systemd-container-ipa-server-install.sh
 

--- a/Dockerfile.fedora-rawhide
+++ b/Dockerfile.fedora-rawhide
@@ -20,6 +20,10 @@ RUN systemctl mask rpc-gssd.service
 # Container image which runs systemd
 # debug: RUN test -f /etc/machine-id && ! test -s /etc/machine-id
 # debug: RUN test "$container" = oci
+
+# Establish reasonably low open files limit in the container
+RUN echo "DefaultLimitNOFILE=1024" >> /etc/systemd/system.conf
+
 ENTRYPOINT [ "/usr/sbin/init" ]
 STOPSIGNAL RTMIN+3
 RUN mkdir /var/log/journal
@@ -51,8 +55,6 @@ ADD hostnamectl-wrapper /usr/bin/nisdomainname
 COPY patches/ipa-fedora-30.patch /root
 RUN set -o pipefail ; patch --verbose -p0 --fuzz=0 < /root/ipa-fedora-30.patch | tee /dev/stderr | sed -n 's/^patching file //;T;/\.py$/p' | xargs python3 -m compileall
 
-# Workaround https://github.com/freeipa/freeipa-container/issues/187
-COPY certmonger-wait-for-ready.conf /usr/lib/systemd/system/certmonger.service.d/wait-for-ready.conf
 # test-addon: VOLUME [ "/var/log/journal" ]
 ## # test: systemd-container-ipa-server-install.sh
 

--- a/Dockerfile.rhel-7
+++ b/Dockerfile.rhel-7
@@ -14,6 +14,10 @@ RUN yum install --disablerepo='*' --enablerepo=rhel-7-server-rpms -y ipa-server 
 
 # Container image which runs systemd
 # debug: RUN test "$container" = oci
+
+# Establish reasonably low open files limit in the container
+RUN echo "DefaultLimitNOFILE=1024" >> /etc/systemd/system.conf
+
 ENTRYPOINT [ "/usr/sbin/init" ]
 STOPSIGNAL RTMIN+3
 # test-addon: VOLUME [ "/var/log/journal" ]

--- a/Dockerfile.rhel-8
+++ b/Dockerfile.rhel-8
@@ -16,6 +16,10 @@ RUN yum -y module install --setopt=install_weak_deps=False idm:DL1/adtrust idm:D
 # Container image which runs systemd
 # debug: RUN test -f /etc/machine-id && ! test -s /etc/machine-id
 # debug: RUN test "$container" = oci
+
+# Establish reasonably low open files limit in the container
+RUN echo "DefaultLimitNOFILE=1024" >> /etc/systemd/system.conf
+
 ENTRYPOINT [ "/usr/sbin/init" ]
 STOPSIGNAL RTMIN+3
 # test-addon: VOLUME [ "/var/log/journal" ]
@@ -46,8 +50,6 @@ ADD hostnamectl-wrapper /usr/bin/nisdomainname
 COPY patches/ipa-rhel-8.patch /root
 RUN set -o pipefail ; patch --verbose -p0 --fuzz=0 < /root/ipa-rhel-8.patch | tee /dev/stderr | sed -n 's/^patching file //;T;/\.py$/p' | xargs /usr/libexec/platform-python -m compileall
 
-# Workaround https://github.com/freeipa/freeipa-container/issues/187
-COPY certmonger-wait-for-ready.conf /usr/lib/systemd/system/certmonger.service.d/wait-for-ready.conf
 # test-addon: VOLUME [ "/var/log/journal" ]
 ## # test: systemd-container-ipa-server-install.sh
 

--- a/certmonger-wait-for-ready.conf
+++ b/certmonger-wait-for-ready.conf
@@ -1,2 +1,0 @@
-[Service]
-ExecStartPost=/bin/bash -c 'while ! dbus-send --system --type=method_call --print-reply --dest=org.fedorahosted.certmonger /org/fedorahosted/certmonger org.freedesktop.DBus.Introspectable.Introspect > /dev/null ; do sleep 5 ; done'


### PR DESCRIPTION
Fixes https://github.com/freeipa/freeipa-container/issues/187.