### PR TITLE
Fix openshift template to work appropriately on OCP 4.X

### DIFF
--- a/freeipa-server-openshift.json
+++ b/freeipa-server-openshift.json
@@ -164,7 +164,7 @@
                 "strategy": {
                     "type": "Recreate",
                     "recreateParams": {
-                        "timeoutSeconds": "${TIMEOUT}"
+                        "timeoutSeconds": "${{TIMEOUT}}"
                     }
                 },
                 "triggers": [


### PR DESCRIPTION
Resolves #289 

This fixes the issue that was seen when processing the openshift template on OCP 4.X.