### PR TITLE
Remove persistent keyring workaround for rhel-8

### DIFF
--- a/patches/ipa-rhel-8.patch
+++ b/patches/ipa-rhel-8.patch
@@ -27,32 +27,3 @@
 +# Workaround https://github.com/systemd/systemd/issues/6281
 +[Service]
 +KeyringMode=inherit
-#
-# Do not use kernel keyring, it is not namespaced
-#
---- /etc/krb5.conf	2018-10-09 20:59:16.000000000 +0000
-+++ /etc/krb5.conf	2018-11-15 14:50:31.177469217 +0000
-@@ -16,7 +16,7 @@
-     pkinit_anchors = /etc/pki/tls/certs/ca-bundle.crt
-     spake_preauth_groups = edwards25519
- #    default_realm = EXAMPLE.COM
--    default_ccache_name = KEYRING:persistent:%{uid}
-+#    default_ccache_name = KEYRING:persistent:%{uid}
- 
- [realms]
- # EXAMPLE.COM = {
-#
-# Prevent the default_ccache_name = KEYRING:persistent:%{uid} from
-# being put back in during ipa-server-install/ipa-replica-install.
-#
---- /usr/lib/python3.6/site-packages/ipapython/kernel_keyring.py	2018-07-19 16:58:12.000000000 +0000
-+++ /usr/lib/python3.6/site-packages/ipapython/kernel_keyring.py	2018-11-15 15:28:57.989157597 +0000
-@@ -75,7 +75,7 @@
-     except ValueError:
-         return False
-
--    return True
-+    return False
-
-
- def has_key(key):


### PR DESCRIPTION
Patch for this workaround landed for FreeIPA 4.8.1
See: https://github.com/freeipa/freeipa/commit/165a941109a9a5f7ac8f85bdda93b4132875a7b1