### PR TITLE
Workaround https://bugs.centos.org/view.php?id=16655.

### DIFF
--- a/Dockerfile.centos-8
+++ b/Dockerfile.centos-8
@@ -9,7 +9,7 @@ RUN groupadd -g 289 ipaapi; useradd -u 289 -g 289 -c 'IPA Framework User' -r -d 
 # Workaround 1615948
 RUN ln -s /bin/false /usr/sbin/systemd-machine-id-setup
 RUN yum -y module enable idm:DL1
-RUN yum -y module install --setopt=install_weak_deps=False idm:DL1/adtrust idm:DL1/dns && yum -y install patch && yum clean all
+RUN yum -y install patch && yum -y module install --setopt=install_weak_deps=False idm:DL1/adtrust idm:DL1/dns && yum clean all
 
 # debug: RUN test $( getent passwd | grep -E "^(dirsrv:x:389|ipaapi:x:289|kdcproxy:x:288|pkiuser:x:17):" | wc -l ) -eq 4
 


### PR DESCRIPTION
Twelve days ago Travis CI run with CentOS 8-based containers passed: https://travis-ci.org/freeipa/freeipa-container/builds/598071630.

Today it failed: https://travis-ci.org/adelton/freeipa-container/jobs/603565501. The error seems similar to https://bugs.centos.org/view.php?id=16655 and even installing the package before the module operation helps as a workaround.