### PR TITLE
Add support for ipa-adtrust-install with /data volume.

### DIFF
--- a/patches/ipa-data-centos-7.patch
+++ b/patches/ipa-data-centos-7.patch
@@ -75,3 +75,29 @@
  #Compress=yes
  #Seal=yes
  #SplitMode=uid
+#
+# Support /var/lib/samba on /data volume
+#
+--- /etc/samba/smb.conf	2019-11-06 11:57:25.000000000 +0000
++++ /etc/samba/smb.conf	2019-11-19 08:54:22.264738866 +0000
+@@ -4,6 +4,7 @@
+ # you modified it.
+ 
+ [global]
++	state directory = /data/var/lib/samba
+ 	workgroup = SAMBA
+ 	security = user
+ 
+--- /usr/lib/python2.7/site-packages/ipaserver/install/adtrustinstance.py	2019-08-14 15:37:23.000000000 +0000
++++ /usr/lib/python2.7/site-packages/ipaserver/install/adtrustinstance.py	2019-11-19 08:34:09.065235181 +0000
+@@ -465,7 +465,9 @@
+         conf_fd.write('### Added by IPA Installer ###\n')
+         conf_fd.write('[global]\n')
+         conf_fd.write('debug pid = yes\n')
+-        conf_fd.write('config backend = registry\n')
++        conf_fd.write('state directory = /data/var/lib/samba\n')
++        conf_fd.write('cache directory = /data/var/lib/samba\n')
++        conf_fd.write('include = registry\n')
+         conf_fd.close()
+ 
+     def __add_plugin_conf(self, name, plugin_cn, ldif_file):

--- a/patches/ipa-data-centos-8.patch
+++ b/patches/ipa-data-centos-8.patch
@@ -96,3 +96,29 @@
  #Compress=yes
  #Seal=yes
  #SplitMode=uid
+#
+# Support /var/lib/samba on /data volume
+#
+--- /etc/samba/smb.conf	2019-11-06 11:57:25.000000000 +0000
++++ /etc/samba/smb.conf	2019-11-19 08:54:22.264738866 +0000
+@@ -4,6 +4,7 @@
+ # you modified it.
+ 
+ [global]
++	state directory = /data/var/lib/samba
+ 	workgroup = SAMBA
+ 	security = user
+ 
+--- /usr/lib/python3.6/site-packages/ipaserver/install/adtrustinstance.py	2019-08-14 15:37:23.000000000 +0000
++++ /usr/lib/python3.6/site-packages/ipaserver/install/adtrustinstance.py	2019-11-19 08:34:09.065235181 +0000
+@@ -465,7 +465,9 @@
+         conf_fd.write('### Added by IPA Installer ###\n')
+         conf_fd.write('[global]\n')
+         conf_fd.write('debug pid = yes\n')
+-        conf_fd.write('config backend = registry\n')
++        conf_fd.write('state directory = /data/var/lib/samba\n')
++        conf_fd.write('cache directory = /data/var/lib/samba\n')
++        conf_fd.write('include = registry\n')
+         conf_fd.close()
+ 
+     def __add_plugin_conf(self, name, plugin_cn, ldif_file):

--- a/patches/ipa-data-fedora-23.patch
+++ b/patches/ipa-data-fedora-23.patch
@@ -84,3 +84,29 @@
  #Compress=yes
  #Seal=yes
  #SplitMode=uid
+#
+# Support /var/lib/samba on /data volume
+#
+--- /etc/samba/smb.conf	2016-11-04 17:09:50.000000000 +0000
++++ /etc/samba/smb.conf	2019-11-19 10:44:12.512868428 +0000
+@@ -86,6 +86,7 @@
+ # max protocol = used to define the supported protocol. The default is NT1. You
+ # can set it to SMB2 if you want experimental SMB2 support.
+ #
++	state directory = /data/var/lib/samba
+ 	workgroup = MYGROUP
+ 	server string = Samba Server Version %v
+ 
+--- /usr/lib/python2.7/site-packages/ipaserver/install/adtrustinstance.py	2019-08-14 15:37:23.000000000 +0000
++++ /usr/lib/python2.7/site-packages/ipaserver/install/adtrustinstance.py	2019-11-19 08:34:09.065235181 +0000
+@@ -465,7 +465,9 @@
+         conf_fd.write('### Added by IPA Installer ###\n')
+         conf_fd.write('[global]\n')
+         conf_fd.write('debug pid = yes\n')
+-        conf_fd.write('config backend = registry\n')
++        conf_fd.write('state directory = /data/var/lib/samba\n')
++        conf_fd.write('cache directory = /data/var/lib/samba\n')
++        conf_fd.write('include = registry\n')
+         conf_fd.close()
+ 
+     def __add_plugin_conf(self, name, plugin_cn, ldif_file):

--- a/patches/ipa-data-fedora-24.patch
+++ b/patches/ipa-data-fedora-24.patch
@@ -84,3 +84,29 @@
  #Compress=yes
  #Seal=yes
  #SplitMode=uid
+#
+# Support /var/lib/samba on /data volume
+#
+--- /etc/samba/smb.conf	2019-11-06 11:57:25.000000000 +0000
++++ /etc/samba/smb.conf	2019-11-19 08:54:22.264738866 +0000
+@@ -4,6 +4,7 @@
+ # you modified it.
+ 
+ [global]
++	state directory = /data/var/lib/samba
+ 	workgroup = SAMBA
+ 	security = user
+ 
+--- /usr/lib/python2.7/site-packages/ipaserver/install/adtrustinstance.py	2019-08-14 15:37:23.000000000 +0000
++++ /usr/lib/python2.7/site-packages/ipaserver/install/adtrustinstance.py	2019-11-19 08:34:09.065235181 +0000
+@@ -465,7 +465,9 @@
+         conf_fd.write('### Added by IPA Installer ###\n')
+         conf_fd.write('[global]\n')
+         conf_fd.write('debug pid = yes\n')
+-        conf_fd.write('config backend = registry\n')
++        conf_fd.write('state directory = /data/var/lib/samba\n')
++        conf_fd.write('cache directory = /data/var/lib/samba\n')
++        conf_fd.write('include = registry\n')
+         conf_fd.close()
+ 
+     def __add_plugin_conf(self, name, plugin_cn, ldif_file):

--- a/patches/ipa-data-fedora-25.patch
+++ b/patches/ipa-data-fedora-25.patch
@@ -84,3 +84,29 @@
  #Compress=yes
  #Seal=yes
  #SplitMode=uid
+#
+# Support /var/lib/samba on /data volume
+#
+--- /etc/samba/smb.conf	2019-11-06 11:57:25.000000000 +0000
++++ /etc/samba/smb.conf	2019-11-19 08:54:22.264738866 +0000
+@@ -4,6 +4,7 @@
+ # you modified it.
+ 
+ [global]
++	state directory = /data/var/lib/samba
+ 	workgroup = SAMBA
+ 	security = user
+ 
+--- /usr/lib/python2.7/site-packages/ipaserver/install/adtrustinstance.py	2019-08-14 15:37:23.000000000 +0000
++++ /usr/lib/python3.7/site-packages/ipaserver/install/adtrustinstance.py	2019-11-19 08:34:09.065235181 +0000
+@@ -465,7 +465,9 @@
+         conf_fd.write('### Added by IPA Installer ###\n')
+         conf_fd.write('[global]\n')
+         conf_fd.write('debug pid = yes\n')
+-        conf_fd.write('config backend = registry\n')
++        conf_fd.write('state directory = /data/var/lib/samba\n')
++        conf_fd.write('cache directory = /data/var/lib/samba\n')
++        conf_fd.write('include = registry\n')
+         conf_fd.close()
+ 
+     def __add_plugin_conf(self, name, plugin_cn, ldif_file):

--- a/patches/ipa-data-fedora-27.patch
+++ b/patches/ipa-data-fedora-27.patch
@@ -94,3 +94,29 @@
  #Compress=yes
  #Seal=yes
  #SplitMode=uid
+#
+# Support /var/lib/samba on /data volume
+#
+--- /etc/samba/smb.conf	2019-11-06 11:57:25.000000000 +0000
++++ /etc/samba/smb.conf	2019-11-19 08:54:22.264738866 +0000
+@@ -4,6 +4,7 @@
+ # you modified it.
+ 
+ [global]
++	state directory = /data/var/lib/samba
+ 	workgroup = SAMBA
+ 	security = user
+ 
+--- /usr/lib/python3.6/site-packages/ipaserver/install/adtrustinstance.py	2019-08-14 15:37:23.000000000 +0000
++++ /usr/lib/python3.6/site-packages/ipaserver/install/adtrustinstance.py	2019-11-19 08:34:09.065235181 +0000
+@@ -465,7 +465,9 @@
+         conf_fd.write('### Added by IPA Installer ###\n')
+         conf_fd.write('[global]\n')
+         conf_fd.write('debug pid = yes\n')
+-        conf_fd.write('config backend = registry\n')
++        conf_fd.write('state directory = /data/var/lib/samba\n')
++        conf_fd.write('cache directory = /data/var/lib/samba\n')
++        conf_fd.write('include = registry\n')
+         conf_fd.close()
+ 
+     def __add_plugin_conf(self, name, plugin_cn, ldif_file):

--- a/patches/ipa-data-fedora-28.patch
+++ b/patches/ipa-data-fedora-28.patch
@@ -96,3 +96,29 @@
  #Compress=yes
  #Seal=yes
  #SplitMode=uid
+#
+# Support /var/lib/samba on /data volume
+#
+--- /etc/samba/smb.conf	2019-11-06 11:57:25.000000000 +0000
++++ /etc/samba/smb.conf	2019-11-19 08:54:22.264738866 +0000
+@@ -4,6 +4,7 @@
+ # you modified it.
+ 
+ [global]
++	state directory = /data/var/lib/samba
+ 	workgroup = SAMBA
+ 	security = user
+ 
+--- /usr/lib/python3.6/site-packages/ipaserver/install/adtrustinstance.py	2019-08-14 15:37:23.000000000 +0000
++++ /usr/lib/python3.6/site-packages/ipaserver/install/adtrustinstance.py	2019-11-19 08:34:09.065235181 +0000
+@@ -465,7 +465,9 @@
+         conf_fd.write('### Added by IPA Installer ###\n')
+         conf_fd.write('[global]\n')
+         conf_fd.write('debug pid = yes\n')
+-        conf_fd.write('config backend = registry\n')
++        conf_fd.write('state directory = /data/var/lib/samba\n')
++        conf_fd.write('cache directory = /data/var/lib/samba\n')
++        conf_fd.write('include = registry\n')
+         conf_fd.close()
+ 
+     def __add_plugin_conf(self, name, plugin_cn, ldif_file):

--- a/patches/ipa-data-fedora-29.patch
+++ b/patches/ipa-data-fedora-29.patch
@@ -96,3 +96,29 @@
  #Compress=yes
  #Seal=yes
  #SplitMode=uid
+#
+# Support /var/lib/samba on /data volume
+#
+--- /etc/samba/smb.conf	2019-11-06 11:57:25.000000000 +0000
++++ /etc/samba/smb.conf	2019-11-19 08:54:22.264738866 +0000
+@@ -4,6 +4,7 @@
+ # you modified it.
+ 
+ [global]
++	state directory = /data/var/lib/samba
+ 	workgroup = SAMBA
+ 	security = user
+ 
+--- /usr/lib/python3.7/site-packages/ipaserver/install/adtrustinstance.py	2019-08-14 15:37:23.000000000 +0000
++++ /usr/lib/python3.7/site-packages/ipaserver/install/adtrustinstance.py	2019-11-19 08:34:09.065235181 +0000
+@@ -465,7 +465,9 @@
+         conf_fd.write('### Added by IPA Installer ###\n')
+         conf_fd.write('[global]\n')
+         conf_fd.write('debug pid = yes\n')
+-        conf_fd.write('config backend = registry\n')
++        conf_fd.write('state directory = /data/var/lib/samba\n')
++        conf_fd.write('cache directory = /data/var/lib/samba\n')
++        conf_fd.write('include = registry\n')
+         conf_fd.close()
+ 
+     def __add_plugin_conf(self, name, plugin_cn, ldif_file):

--- a/patches/ipa-data-fedora-30.patch
+++ b/patches/ipa-data-fedora-30.patch
@@ -102,3 +102,29 @@
  #Compress=yes
  #Seal=yes
  #SplitMode=uid
+#
+# Support /var/lib/samba on /data volume
+#
+--- /etc/samba/smb.conf	2019-11-06 11:57:25.000000000 +0000
++++ /etc/samba/smb.conf	2019-11-19 08:54:22.264738866 +0000
+@@ -4,6 +4,7 @@
+ # you modified it.
+ 
+ [global]
++	state directory = /data/var/lib/samba
+ 	workgroup = SAMBA
+ 	security = user
+ 
+--- /usr/lib/python3.7/site-packages/ipaserver/install/adtrustinstance.py	2019-08-14 15:37:23.000000000 +0000
++++ /usr/lib/python3.7/site-packages/ipaserver/install/adtrustinstance.py	2019-11-19 08:34:09.065235181 +0000
+@@ -465,7 +465,9 @@
+         conf_fd.write('### Added by IPA Installer ###\n')
+         conf_fd.write('[global]\n')
+         conf_fd.write('debug pid = yes\n')
+-        conf_fd.write('config backend = registry\n')
++        conf_fd.write('state directory = /data/var/lib/samba\n')
++        conf_fd.write('cache directory = /data/var/lib/samba\n')
++        conf_fd.write('include = registry\n')
+         conf_fd.close()
+ 
+     def __add_plugin_conf(self, name, plugin_cn, ldif_file):

--- a/patches/ipa-data-fedora-32.patch
+++ b/patches/ipa-data-fedora-32.patch
@@ -102,3 +102,29 @@
  #Compress=yes
  #Seal=yes
  #SplitMode=uid
+#
+# Support /var/lib/samba on /data volume
+#
+--- /etc/samba/smb.conf	2019-11-06 11:57:25.000000000 +0000
++++ /etc/samba/smb.conf	2019-11-19 08:54:22.264738866 +0000
+@@ -4,6 +4,7 @@
+ # you modified it.
+ 
+ [global]
++	state directory = /data/var/lib/samba
+ 	workgroup = SAMBA
+ 	security = user
+ 
+--- /usr/lib/python3.8/site-packages/ipaserver/install/adtrustinstance.py	2019-08-14 15:37:23.000000000 +0000
++++ /usr/lib/python3.8/site-packages/ipaserver/install/adtrustinstance.py	2019-11-19 08:34:09.065235181 +0000
+@@ -465,7 +465,9 @@
+         conf_fd.write('### Added by IPA Installer ###\n')
+         conf_fd.write('[global]\n')
+         conf_fd.write('debug pid = yes\n')
+-        conf_fd.write('config backend = registry\n')
++        conf_fd.write('state directory = /data/var/lib/samba\n')
++        conf_fd.write('cache directory = /data/var/lib/samba\n')
++        conf_fd.write('include = registry\n')
+         conf_fd.close()
+ 
+     def __add_plugin_conf(self, name, plugin_cn, ldif_file):

--- a/patches/ipa-data-rhel-8.patch
+++ b/patches/ipa-data-rhel-8.patch
@@ -98,3 +98,29 @@
  #Compress=yes
  #Seal=yes
  #SplitMode=uid
+#
+# Support /var/lib/samba on /data volume
+#
+--- /etc/samba/smb.conf	2019-11-06 11:57:25.000000000 +0000
++++ /etc/samba/smb.conf	2019-11-19 08:54:22.264738866 +0000
+@@ -4,6 +4,7 @@
+ # you modified it.
+ 
+ [global]
++	state directory = /data/var/lib/samba
+ 	workgroup = SAMBA
+ 	security = user
+ 
+--- /usr/lib/python3.6/site-packages/ipaserver/install/adtrustinstance.py	2019-08-14 15:37:23.000000000 +0000
++++ /usr/lib/python3.6/site-packages/ipaserver/install/adtrustinstance.py	2019-11-19 08:34:09.065235181 +0000
+@@ -465,7 +465,9 @@
+         conf_fd.write('### Added by IPA Installer ###\n')
+         conf_fd.write('[global]\n')
+         conf_fd.write('debug pid = yes\n')
+-        conf_fd.write('config backend = registry\n')
++        conf_fd.write('state directory = /data/var/lib/samba\n')
++        conf_fd.write('cache directory = /data/var/lib/samba\n')
++        conf_fd.write('include = registry\n')
+         conf_fd.close()
+ 
+     def __add_plugin_conf(self, name, plugin_cn, ldif_file):

--- a/tests/run-master-and-replica.sh
+++ b/tests/run-master-and-replica.sh
@@ -150,6 +150,8 @@ set -x
 $docker exec freeipa-master bash -c 'echo Secret123 | kinit admin'
 $docker exec freeipa-master ipa user-add --first Bob --last Nowak bob
 $docker exec freeipa-master id bob
+
+$docker exec freeipa-master ipa-adtrust-install -a Secret123 --netbios-name=EXAMPLE -U
 )
 
 if [ "$replica" = 'none' ] ; then

--- a/tests/systemd-container-ipa-server-install-data.sh
+++ b/tests/systemd-container-ipa-server-install-data.sh
@@ -12,6 +12,9 @@ EXIT=false
 if ! $docker exec $C ipa-server-install -U -r EXAMPLE.TEST -p Secret123 -a Secret123 --setup-dns --no-forwarders --no-ntp ; then
 	EXIT=true
 fi
+if ! "$EXIT" && ! $docker exec $C ipa-adtrust-install -a Secret123 --netbios-name=EXAMPLE -U ; then
+	EXIT=true
+fi
 FAILED=$( $docker exec $C systemctl list-units --state=failed --no-pager -l --no-legend | tee /dev/stderr | sed 's/ .*//' | sort )
 for s in $FAILED ; do
 	$docker exec $C systemctl status $s --no-pager -l || :

--- a/volume-data-list
+++ b/volume-data-list
@@ -73,6 +73,7 @@
 /var/log/krb5kdc.log
 /var/log/lastlog
 /var/log/pki/
+/var/log/samba/
 /var/log/sssd/
 /var/log/wtmp
 /var/named/


### PR DESCRIPTION
Addressing `ipa-adtrust-install` failing with
```
  [5/24]: creating samba config registry
  [error] CalledProcessError: CalledProcessError(Command ['/usr/bin/net', 'conf', 'import', '/tmp/tmpi97o8hgm'] returned non-zero exit status 255: 'Failed to initialize the registry: WERR_NOT_ENOUGH_MEMORY\n')
```

Fixes https://github.com/freeipa/freeipa-container/issues/280.