### PR TITLE
Remove workaround for persistent keyring krb5.conf and ipa-replica-install

### DIFF
--- a/patches/ipa-rhel-7.patch
+++ b/patches/ipa-rhel-7.patch
@@ -12,32 +12,3 @@
                                         socket.AF_UNSPEC, socket.SOCK_STREAM)
      except socket.error as ex:
          if ex.errno == socket.EAI_NODATA or ex.errno == socket.EAI_NONAME:
-#
-# Do not use kernel keyring, it is not namespaced
-#
---- /etc/krb5.conf	2018-08-01 19:26:13.000000000 +0000
-+++ /etc/krb5.conf	2018-11-19 10:47:57.752696130 +0000
-@@ -14,7 +14,7 @@
-  rdns = false
-  pkinit_anchors = FILE:/etc/pki/tls/certs/ca-bundle.crt
- # default_realm = EXAMPLE.COM
-- default_ccache_name = KEYRING:persistent:%{uid}
-+# default_ccache_name = KEYRING:persistent:%{uid}
- 
- [realms]
- # EXAMPLE.COM = {
-#
-# Prevent the default_ccache_name = KEYRING:persistent:%{uid} from
-# being put back in during ipa-server-install/ipa-replica-install.
-#
---- /usr/lib/python2.7/site-packages/ipapython/kernel_keyring.py	2019-08-26 07:09:35.398825862 +0000
-+++ /usr/lib/python2.7/site-packages/ipapython/kernel_keyring.py	2019-08-26 07:10:21.626456952 +0000
-@@ -75,7 +75,7 @@
-     except ValueError:
-         return False
- 
--    return True
-+    return False
- 
- 
- def has_key(key):


### PR DESCRIPTION
Remove workaround for persistent keyring krb5.conf and ipa-replica-install because latest RHEL 7.8 release has this patched in ipa-[server|replica]-install.

Signed-off-by: Tibor Dudlák <tdudlak@redhat.com>