### PR TITLE
Create machine-id early

### DIFF
--- a/Dockerfile.fedora-32
+++ b/Dockerfile.fedora-32
@@ -77,7 +77,7 @@ VOLUME [ "/tmp", "/run", "/data", "/var/log/journal" ]
 
 COPY init-data-minimal /usr/local/sbin/init
 ENTRYPOINT [ "/usr/local/sbin/init" ]
-# test: systemd-container-ipa-server-install-data.sh docker-diff-minimal-fedora-23.out
+# test: systemd-container-ipa-server-install-data.sh /dev/null
 
 # Configure master/replica upon the first invocation
 COPY init-data /usr/local/sbin/init

--- a/README
+++ b/README
@@ -55,10 +55,6 @@ to point it to itself. Add `--dns=127.0.0.1` option to the
 `docker run` invocation to allow the FreeIPA server to reach its own
 DNS server.
 
-Also, without oci-systemd-hook, running the container as
-`--read-only` will typically only work when `/etc/machine-id`
-is pre-created on the host and bind-mounted to the container with `-v`.
-
 The list of options [opts] can start with exit-on-finished to stop
 the container after successfully configuring the server in the container
 (useful for testing), or no-exit to keep the container running even

--- a/init-data
+++ b/init-data
@@ -49,8 +49,11 @@ done
 # Workaround 1373562
 mkdir -p /run/lock
 
-mkdir -p /run/ipa /run/log /data/var/log/journal
-ln -s /data/var/log/journal /run/log/journal
+DATA=/data
+DATA_TEMPLATE=/data-template
+
+mkdir -p /run/ipa /run/log $DATA/var/log/journal
+ln -s $DATA/var/log/journal /run/log/journal
 
 if [ "$1" == 'no-exit' -o -n "$DEBUG_NO_EXIT" ] ; then
 	if [ "$1" == 'no-exit' ] ; then
@@ -75,7 +78,6 @@ fi
 # Debugging:  Turn on tracing of ipa-server-configure-first script
 test -z "$DEBUG_TRACE" || touch /run/ipa/debug-trace
 
-DATA=/data
 COMMAND=
 if [ -n "$1" ] ; then
 	case "$1" in
@@ -169,12 +171,20 @@ if ! [ -f "$DATA/hostname" ] ; then
 	echo "$HOSTNAME" > "$DATA/hostname"
 fi
 
-DATA_TEMPLATE=/data-template
+function create_machine_id () {
+	# only triggers when /etc/machine-id is a symlink and not bind-mounted into
+	# the container by a container runtime.
+	if [ -L /etc/machine-id -a ! -f $DATA/etc/machine-id ] ; then
+		dbus-uuidgen --ensure=$DATA/etc/machine-id
+		chmod 444 $DATA/etc/machine-id
+	fi
+}
 
 if ! [ -f /etc/ipa/ca.crt ] ; then
 	if ! [ -f $DATA/ipa.csr ] ; then
 		# Do not refresh $DATA in the second stage of the external CA setup
-		/usr/local/bin/populate-volume-from-template /data
+		/usr/local/bin/populate-volume-from-template $DATA
+		create_machine_id
 	fi
 	if [ -n "$PASSWORD" ] ; then
 		if [ "$COMMAND" == 'ipa-server-install' ] ; then
@@ -226,7 +236,8 @@ fi
 if [ -f "$DATA/build-id" ] ; then
 	if ! cmp -s $DATA/build-id $DATA_TEMPLATE/build-id ; then
 		echo "FreeIPA server is already configured but with different version, volume update."
-		/usr/local/bin/populate-volume-from-template /data
+		/usr/local/bin/populate-volume-from-template $DATA
+		create_machine_id
 		sha256sum -c /etc/volume-data-autoupdate 2> /dev/null | awk -F': ' '/OK$/ { print $1 }' \
 			| while read f ; do
 				rm -f "$DATA/$f"

--- a/tests/docker-diff-ipa.out
+++ b/tests/docker-diff-ipa.out
@@ -1,4 +1,3 @@
-^[CD] /etc/machine-id$
 ^C /usr$
 ^[AD] /usr/dev$
 ^[AD] /usr/etc$

--- a/tests/run-master-and-replica.sh
+++ b/tests/run-master-and-replica.sh
@@ -79,23 +79,13 @@ function run_ipa_container() {
 	if [ "$docker" != "sudo podman" -a "$docker" != "podman" ] && [ -n "$seccomp" ] ; then
 		SEC_OPTS="--security-opt=seccomp:$seccomp"
 	fi
-	VOLUME_OPTS=
-	if [ -n "$readonly_run" -a -n "$TRAVIS" ] ; then
-		if ! [ -f $VOLUME/etc/machine-id ] ; then
-			mkdir -p $VOLUME/etc
-			chmod o+rx $VOLUME/etc
-			uuidgen | sed 's/-//g' > $VOLUME/etc/machine-id
-			chmod 444 $VOLUME/etc/machine-id
-		fi
-		VOLUME_OPTS="-v $VOLUME/etc/machine-id:/etc/machine-id:ro,Z"
-	fi
 	(
 	set -x
 	umask 0
 	$docker run $readonly_run -d --name "$N" -h $HOSTNAME \
 		$SEC_OPTS --sysctl net.ipv6.conf.all.disable_ipv6=0 \
 		--tmpfs /run --tmpfs /tmp -v /dev/urandom:/dev/random:ro -v /sys/fs/cgroup:/sys/fs/cgroup:ro \
-		-v $VOLUME:/data:Z $VOLUME_OPTS $DOCKER_RUN_OPTS \
+		-v $VOLUME:/data:Z $DOCKER_RUN_OPTS \
 		-e PASSWORD=Secret123 "$IMAGE" "$@"
 	)
 	wait_for_ipa_container "$N" "$@"

--- a/tests/systemd-container-ipa-server-install-data.sh
+++ b/tests/systemd-container-ipa-server-install-data.sh
@@ -38,7 +38,7 @@ if [ -e /var/log/journal/$MACHINE_ID ] ; then
 	exit 1
 fi
 
-$docker diff $C | tee /dev/stderr | grep -v '^C /etc$' | sort | diff tests/$D /dev/stdin
+$docker diff $C | tee /dev/stderr | sort | ( cd tests && diff $D /dev/stdin )
 
 echo OK $0.
 

--- a/volume-data-list
+++ b/volume-data-list
@@ -10,6 +10,7 @@
 /etc/krb5.conf
 /etc/krb5.conf.d/
 /etc/krb5.keytab
+/etc/machine-id
 /etc/named.conf
 /etc/named.keytab
 /etc/named/ipa-ext.conf


### PR DESCRIPTION
D-Bus requires a proper /etc/machine-id to work. The file
/etc/machine-id is empty by default. In a read-only container D-Bus is
unable to create machine-id in /etc/ or /var/lib/dbus/ and then fails
with a cryptic error message:

   ERROR launcher_run_child @ ../src/launch/launcher.c +325: No medium found

The init-data script now creates a /data/etc/machine-id when the file
does not exist and /etc/machine-id is a symlink. By default
/etc/machine-id is a symlink to /data/etc/machine-id. Container runtimes
are still free to bind-mount a custom /etc/machine-id.

Signed-off-by: Christian Heimes <cheimes@redhat.com>