### PR TITLE
Configure journald storage with drop-in file

### DIFF
--- a/Dockerfile.centos-8
+++ b/Dockerfile.centos-8
@@ -57,6 +57,8 @@ RUN set -o pipefail ; patch --verbose -p0 --fuzz=0 < /root/ipa-rhel-8.patch | te
 COPY patches/ipa-data-rhel-8.patch /root
 RUN set -o pipefail ; patch --verbose -p0 --fuzz=0 < /root/ipa-data-rhel-8.patch | tee /dev/stderr | sed -n 's/^patching file //;T;/\.py$/p' | xargs /usr/libexec/platform-python -m compileall
 
+COPY journald-storage.conf /usr/lib/systemd/journald.conf.d/storage.conf
+
 RUN mv /usr/sbin/ipa-join /usr/sbin/ipa-join.orig
 COPY ipa-join /usr/sbin/ipa-join
 

--- a/Dockerfile.fedora-32
+++ b/Dockerfile.fedora-32
@@ -60,6 +60,8 @@ RUN /usr/local/bin/extract-rpm-upgrade-scriptlets
 COPY patches/ipa-data-fedora-32.patch /root
 RUN set -o pipefail ; patch --verbose -p0 --fuzz=0 < /root/ipa-data-fedora-32.patch | tee /dev/stderr | sed -n 's/^patching file //;T;/\.py$/p' | xargs python3 -m compileall
 
+COPY journald-storage.conf /usr/lib/systemd/journald.conf.d/storage.conf
+
 RUN mv /usr/sbin/ipa-join /usr/sbin/ipa-join.orig
 COPY ipa-join /usr/sbin/ipa-join
 

--- a/Dockerfile.fedora-rawhide
+++ b/Dockerfile.fedora-rawhide
@@ -60,6 +60,8 @@ RUN /usr/local/bin/extract-rpm-upgrade-scriptlets
 COPY patches/ipa-data-fedora-33.patch /root
 RUN set -o pipefail ; patch --verbose -p0 --fuzz=0 < /root/ipa-data-fedora-33.patch | tee /dev/stderr | sed -n 's/^patching file //;T;/\.py$/p' | xargs python3 -m compileall
 
+COPY journald-storage.conf /usr/lib/systemd/journald.conf.d/storage.conf
+
 RUN mv /usr/sbin/ipa-join /usr/sbin/ipa-join.orig
 COPY ipa-join /usr/sbin/ipa-join
 

--- a/Dockerfile.rhel-8
+++ b/Dockerfile.rhel-8
@@ -55,6 +55,8 @@ RUN set -o pipefail ; patch --verbose -p0 --fuzz=0 < /root/ipa-rhel-8.patch | te
 COPY patches/ipa-data-rhel-8.patch /root
 RUN set -o pipefail ; patch --verbose -p0 --fuzz=0 < /root/ipa-data-rhel-8.patch | tee /dev/stderr | sed -n 's/^patching file //;T;/\.py$/p' | xargs /usr/libexec/platform-python -m compileall
 
+COPY journald-storage.conf /usr/lib/systemd/journald.conf.d/storage.conf
+
 RUN mv /usr/sbin/ipa-join /usr/sbin/ipa-join.orig
 COPY ipa-join /usr/sbin/ipa-join
 

--- a/journald-storage.conf
+++ b/journald-storage.conf
@@ -1,0 +1,5 @@
+# Force writing journal to /run/log/journal which we symlink to
+# /data/var/log/journal
+[Journal]
+Storage=volatile
+

--- a/patches/ipa-data-fedora-32.patch
+++ b/patches/ipa-data-fedora-32.patch
@@ -95,21 +95,6 @@
  d /var/cache 0755 - - -
 
 #
-# Force writing journal to /run/log/journal which we symlink to
-# /data/var/log/journal
-#
---- /etc/systemd/journald.conf	2016-02-01 14:04:05.000000000 +0000
-+++ /etc/systemd/journald.conf	2018-12-14 08:49:25.189295557 +0000
-@@ -12,7 +12,7 @@
- # See journald.conf(5) for details.
- 
- [Journal]
--#Storage=auto
-+Storage=volatile
- #Compress=yes
- #Seal=yes
- #SplitMode=uid
-#
 # Support /var/lib/samba on /data volume
 #
 --- /etc/samba/smb.conf	2019-11-06 11:57:25.000000000 +0000

--- a/patches/ipa-data-fedora-33.patch
+++ b/patches/ipa-data-fedora-33.patch
@@ -95,21 +95,6 @@
  d /var/cache 0755 - - -
 
 #
-# Force writing journal to /run/log/journal which we symlink to
-# /data/var/log/journal
-#
---- /etc/systemd/journald.conf	2016-02-01 14:04:05.000000000 +0000
-+++ /etc/systemd/journald.conf	2018-12-14 08:49:25.189295557 +0000
-@@ -12,7 +12,7 @@
- # See journald.conf(5) for details.
- 
- [Journal]
--#Storage=auto
-+Storage=volatile
- #Compress=yes
- #Seal=yes
- #SplitMode=uid
-#
 # Support /var/lib/samba on /data volume
 #
 --- /etc/samba/smb.conf	2019-11-06 11:57:25.000000000 +0000

--- a/patches/ipa-data-rhel-8.patch
+++ b/patches/ipa-data-rhel-8.patch
@@ -87,21 +87,6 @@
  d /var/cache 0755 - - -
 
 #
-# Force writing journal to /run/log/journal which we symlink to
-# /data/var/log/journal
-#
---- /etc/systemd/journald.conf	2016-02-01 14:04:05.000000000 +0000
-+++ /etc/systemd/journald.conf	2018-12-14 08:49:25.189295557 +0000
-@@ -12,7 +12,7 @@
- # See journald.conf(5) for details.
-
- [Journal]
--#Storage=auto
-+Storage=volatile
- #Compress=yes
- #Seal=yes
- #SplitMode=uid
-#
 # Support /var/lib/samba on /data volume
 #
 --- /etc/samba/smb.conf	2019-11-06 11:57:25.000000000 +0000


### PR DESCRIPTION
There is no need to patch global journald.conf file. journald reads
configuration snippets from /usr/lib/systemd/journald.conf.d/*.conf.

Signed-off-by: Christian Heimes <cheimes@redhat.com>