### PR TITLE
Silence error message in journald check

### DIFF
--- a/tests/run-master-and-replica.sh
+++ b/tests/run-master-and-replica.sh
@@ -55,7 +55,8 @@ function wait_for_ipa_container() {
 	if [ -n "$MACHINE_ID" ] ; then
 		# Check that journal landed on volume and not in host's /var/log/journal
 		$sudo ls -la $VOLUME/var/log/journal/$MACHINE_ID
-		if ls -la /var/log/journal/$MACHINE_ID ; then
+		if [ -e /var/log/journal/$MACHINE_ID ] ; then
+			ls -la /var/log/journal/$MACHINE_ID
 			exit 1
 		fi
 	fi

--- a/tests/systemd-container-ipa-server-install-data.sh
+++ b/tests/systemd-container-ipa-server-install-data.sh
@@ -31,7 +31,10 @@ $docker exec $C id bob
 
 MACHINE_ID=$( $docker exec $C cat /etc/machine-id )
 $docker exec $C ls -la /data/var/log/journal/$MACHINE_ID/system.journal /data/var/log/ipaserver-install.log
-if ls -la /var/log/journal/$MACHINE_ID ; then
+
+# Check that journal landed on volume and not in host's /var/log/journal
+if [ -e /var/log/journal/$MACHINE_ID ] ; then
+	ls -la /var/log/journal/$MACHINE_ID
 	exit 1
 fi
 


### PR DESCRIPTION
The test suite no longer prints an error message like

   ls: cannot access '/var/log/journal/a3bd8db7322543a98dd75d2485d51ec5': No such file or directory

when it checks for a local mount point on the host file system.

See: https://github.com/freeipa/freeipa-container/pull/335
Signed-off-by: Christian Heimes <cheimes@redhat.com>