### PR TITLE
Document podman invocation in README, use the documented parameters in tests.

### DIFF
--- a/README
+++ b/README
@@ -1,137 +1,136 @@
 # FreeIPA server container
 
+## Building FreeIPA server image
+
 This repository contains Dockerfiles and associated assets for
-building a FreeIPA server container images from the official yum/dnf
+building FreeIPA server container images from the official yum/dnf
 repositories.
 
-Install docker 1.10+:
+There are multiple `Dockerfile`s available for images based on various
+operating systems. Use `-f` option to `podman build` or `docker build`
+to pick a specific operating system. For example, running
 
-    yum install -y docker
+    podman build -t freeipa-server -f Dockerfile.centos-8 .
 
-Start the service:
+will build image based on CentOS 8 packages using podman, and with
 
-    systemctl start docker
+    docker build -t freeipa-server -f Dockerfile.fedora-rawhide .
 
-To build the image, run in the root of the repository:
+FreeIPA image based on Fedora rawhide will be built with docker.
+Note that when using docker / moby-engine, the docker daemon needs
+to be running.
 
-    docker build -t freeipa-server .
+## Running FreeIPA server container
 
-The repository contains multiple `Dockerfile`s for various
-operating systems. Use `-f` option to `docker build` to pick
-different than default target.
-
-Create directory which will hold the server data:
-
-    mkdir /var/lib/ipa-data
-
-On SELinux enabled systems,
+The FreeIPA container runs systemd to manage all the necessary services
+within a single container. On SELinux enabled systems, it may be
+necessary to enable running systemd in containers by setting SELinux
+boolean `container_manage_cgroup` on the host with
 
     setsebool -P container_manage_cgroup 1
 
-might be needed to enable running systemd in the containers.
+The FreeIPA container will store all its configurations and data on
+volume mounted to `/data` directory in the container. If we create
+directory which will hold the server data on the host with
 
-On systems where oci-systemd-hook is available on the host, the
-FreeIPA server container can be created with
+    mkdir /var/lib/ipa-data
+
+we can then create the FreeIPA container with podman using
+
+    podman run --name freeipa-server-container -ti \
+        -h ipa.example.test --read-only \
+        -v /var/lib/ipa-data:/data:Z freeipa-server [ opts ]
+
+and with docker using
 
     docker run --name freeipa-server-container -ti \
-       -h ipa.example.test \
-       --read-only \
-       -v /var/lib/ipa-data:/data:Z freeipa-server [ opts ]
+        -h ipa.example.test --read-only \
+        -v /sys/fs/cgroup:/sys/fs/cgroup:ro \
+        -v /var/lib/ipa-data:/data:Z freeipa-server [ opts ]
 
-Without oci-systemd-hook, `/run`, `/tmp`, and `/sys/fs/cgroup`
-need to be mounted explicitly:
+Note the `-v /sys/fs/cgroup:/sys/fs/cgroup:ro` option in the `docker run`
+case -- depending on your version of docker, it may or may not be
+necessary.
 
-    docker run --name freeipa-server-container -ti \
-       -h ipa.example.test \
-       -v /sys/fs/cgroup:/sys/fs/cgroup:ro \
-       --tmpfs /run --tmpfs /tmp \
-       -v /var/lib/ipa-data:/data:Z freeipa-server [ opts ]
+If you receive error like
 
-When running DNS server (the `--setup-dns` option to
+    IPv6 stack is enabled in the kernel but there is no interface that
+    has ::1 address assigned. Add ::1 address resolution to 'lo' interface.
+    You might need to enable IPv6 on the interface 'lo' in sysctl.conf.
+
+you might also need to add option
+
+        --sysctl net.ipv6.conf.all.disable_ipv6=0
+
+When running DNS server (the `--setup-dns` argument to
 `ipa-server-install`) in a container with read-only root filesystem
-(the `--read-only` option to `docker run`), the setup code in the
-container won't be able to edit `/etc/resolv.conf` in the container
-to point it to itself. Add `--dns=127.0.0.1` option to the
-`docker run` invocation to allow the FreeIPA server to reach its own
-DNS server.
+(the `--read-only` option to `podman run` or `docker run`), the setup
+code in the container won't be able to edit `/etc/resolv.conf` in the
+container to point it to itself. Add `--dns=127.0.0.1` option to the
+`podman run` or `docker run` invocation to allow the FreeIPA server
+to reach its own DNS server.
 
-The list of options [opts] can start with exit-on-finished to stop
-the container after successfully configuring the server in the container
-(useful for testing), or no-exit to keep the container running even
-if the initial configuration fails (useful for debugging).
-
-Standard `ipa-server-install` will be started and you can configure
-the server. The `docker run` invocation also accepts command line
-parameters that will be passed to `ipa-server-install`, so
-unattended invocation is possible, for example with
-
-    docker run --rm -e PASSWORD=Secret123 -h ipa.example.test --read-only \
-        freeipa-server exit-on-finished -U -r EXAMPLE.TEST --no-ntp
-
-To allow for unprivileged container operation, use the `docker run -h ...`
+To allow for unprivileged container operation, use the `-h ...`
 option to set the hostname for the FreeIPA server in the container.
 If it's not possible to set the hostname for the container, specify it
 with `IPA_SERVER_HOSTNAME` environment variable, for example with
-`docker run -e IPA_SERVER_HOSTNAME=...`.
-Do not use the `ipa-server-install --hostname ...` option.
+`podman run -e IPA_SERVER_HOSTNAME=...`. This might however not work
+with read-only containers.
+Do not use the `ipa-server-install --hostname ...` argument.
 
-Optionally, you can put into the directory mounted into /data
-(/var/lib/ipa-data in this example) a file
+Upon the first invocation with empty directory mounted to `/data`,
+the container will run either `ipa-server-install` or `ipa-replica-install`
+to configure FreeIPA master or replica. For example
 
-    ipa-server-install-options
+    podman run -ti -h ipa.example.test --read-only \
+        -v /var/lib/ipa-data:/data:Z \
+        freeipa-server ipa-server-install -r EXAMPLE.TEST --no-ntp
 
-with command line parameters to ipa-server-install command,
-for example
+will run interactive `ipa-server-install` and configure the FreeIPA master
+using the inputs provided. For unattended initial installation, use
+the `-U` argument to `ipa-server-install` and specify all the necessary
+inputs as argument on the command line, for example
+
+    docker run -ti -h ipa.example.test --read-only \
+        -v /sys/fs/cgroup:/sys/fs/cgroup:ro \
+        -v /var/lib/ipa-data:/data:Z \
+        -e PASSWORD=Secret123 \
+        freeipa-server ipa-server-install -U -r EXAMPLE.TEST --no-ntp
+
+The `ipa-server-install` command is the default and can be omitted.
+
+Sometimes it is not convenient or possible to specify the arguments
+to `ipa-server-install` as arguments to `podman run` or `docker run`.
+In the case they can be specified either using environment variable
+`IPA_SERVER_INSTALL_OPTS` using the `-e` option, or they can be passed
+in using file `ipa-server-install-options` in the directory mounted
+to the container as `/data`. For example, when
+`/var/lib/ipa-data/ipa-server-install-options` contains
 
     --realm=EXAMPLE.TEST
     --ds-password=The-directory-server-password
     --admin-password=The-admin-password
 
-and these options will also be used as parameters to `ipa-server-install`.
+and `podman run` or `docker run` is executed with
+`-v /var/lib/ipa-data:/data:Z`, the content of
+`ipa-server-install-options` will be passed as arguments to
+`ipa-server-install`.
 
 If you want to instruct the container to create a replica, specify the
-command in the `docker run` parameters:
+`ipa-replica-install` command in the `podman run` or `docker run`
+parameters:
 
-    docker run --name freeipa-server-container -ti \
-       -h ipa.example.test \
-       -v /sys/fs/cgroup:/sys/fs/cgroup:ro \
-       --tmpfs /run --tmpfs /tmp \
+    podman run -ti -h ipa.example.test --read-only \
        -v /var/lib/ipa-data:/data:Z \
        freeipa-server ipa-replica-install [ opts ]
 
-The options will be passed to `ipa-replica-install` in the container.
-You can also put options to file
+Using `ipa-replica-install-options` also works and will invoke
+`ipa-replica-install` and pass it its content as argument, the same
+way `ipa-server-install-options` works for `ipa-server-install`.
 
-    ipa-replica-install-options
-
-in the directory mounted to /data to this directory, for example with
-
-    --password=The-directory-server-password
-    --admin-password=The-admin-password
-
-If your setup is of Domain Level < 1, GPG-encrypted replica information
-file is also needed in the directory mounted to /data.
-
-If the above commands fail with error about invalid value for
-flag -v and bad format for volumes, run
-
-    chcon -t svirt_sandbox_file_t /var/lib/ipa-data
-
-or use semanage fcontext and restorecon, and use -v option
-without the :Z part.
-
-The option `--name` assigns the container a name that can be used
-later with `docker start`, `docker stop` and other commands.
-Command `ipa-server-install` is invoked non-interactively the first
-time the container is run.
-
-The `-ti` parameters are optional and are used for get a terminal,
-for interactive configuration sessions.
-
-The container can the be started and stopped:
-
-    docker stop freeipa-server-container
-    docker start -ai freeipa-server-container
+Upon subsequent invocations when `/data` is found already populated
+with FreeIPA server configuration and data, the options are ignored
+and just the necessary services started in the container.
 
 If you want to use the FreeIPA server not just from the host
 where it is running but from external machines as well, you
@@ -146,18 +145,17 @@ address. Starting the server would then be
 	-p 88:88/udp -p 464:464/udp -p 123:123/udp ...
 
 Note that an attempt of achieving this goal with the `--ip-address`
-option of `ipa-server-install` command is likely to fail, and should
-be avoided.
+option of `ipa-server-install` command might fail.
 
 If you have existing container with data volume, it should be safe
 to shut it down and run new one based on newer image, with the same
-data directory bind-mounted to /data. The container will detect
+data directory bind-mounted to `/data`. The container logic will detect
 that it is running with data produced by different image and attempt
 to upgrade the configuration and data. Of course, keeping backup
 of the data directory for cases when the upgrade process fails
 is recommended.
 
-# Configuring and running with atomic
+## Configuring and running with atomic
 
 On platforms with `atomic` command available, the container can be
 configured with
@@ -182,7 +180,7 @@ and data. It the gets started with
 
 Version 1.12 of atomic is needed.
 
-# IPA-enrolled client in Docker
+## IPA-enrolled client in Docker
 
 There are multiple `*-client` branches named after OS they are
 based on. Check out the branch you prefer and in the root of the
@@ -200,7 +198,7 @@ freeipa-server container directly:
 The first time this container runs, it invokes `ipa-client-install`
 with the given admin password.
 
-# Debugging
+## Debugging
 
 The container scripts provide some options for debugging:
 
@@ -211,11 +209,21 @@ The container scripts provide some options for debugging:
 - Disable container exit after script failure by setting the
   `$DEBUG_NO_EXIT` environment variable.  After failure, the
   container will continue running, and can be entered for debugging
-  with e.g. `docker exec -it freeipa-server-container bash`.
+  with e.g. `podman exec -it freeipa-server-container bash`.
+  This can also be achieved by specifying `no-exit` as the first
+  word in the [opts] to the container.
+
+- Force container exit after successfully configuring the FreeIPA
+  server by specifying `exit-on-finished` as the first word in the
+  [opts] to the container.
 
 Example usage:
 
-    docker run [...] -e DEBUG_TRACE=1 -e DEBUG_NO_EXIT=1 freeipa-server
+    podman run [...] -e DEBUG_TRACE=1 -e DEBUG_NO_EXIT=1 freeipa-server
+
+or
+
+    docker run [...] freeipa-server exit-on-finished -U -r EXAMPLE.TEST
 
 You can also try to run
 
@@ -223,17 +231,18 @@ You can also try to run
 
 or
 
-    docker='sudo podman' tests/run-partial-tests.sh Dockerfile
+    docker=podman tests/run-partial-tests.sh Dockerfile
 
 which can uncover the general issues with running systemd in containers.
 
-# Travis CI
+## GitHub Actions and Travis CI
 
-To check the general health of the project, you can check
+To check the general health of the project, see
+https://github.com/freeipa/freeipa-container/actions and
 https://travis-ci.org/freeipa/freeipa-container/ where tests are run
-for various OSes (in the container).
+for various OS versions in the containers.
 
-# License
+## License
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
Fixes https://github.com/freeipa/freeipa-container/issues/186.