### PR TITLE
Push built images to Docker Hub when tests pass

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -161,3 +161,35 @@ jobs:
       - name: Run K3s and master in it
         run: tests/run-master-in-k3s.sh local/freeipa-server:${{ matrix.os }} freeipa-server-${{ matrix.os }}.tar
 
+  push-after-success:
+    name: Push images to Docker Hub
+    runs-on: ubuntu-20.04
+    needs: [ test-docker, test-podman, test-rootless-podman, test-k3s ]
+    if: github.event_name == 'push' && github.repository == 'freeipa/freeipa-container' && github.ref == 'refs/heads/master'
+    steps:
+      - name: Log in to Docker Hub
+        env:
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+        run: echo "$DOCKER_PASSWORD" | skopeo login -u "$DOCKER_USERNAME" --password-stdin docker.io
+      - uses: actions/download-artifact@v2
+        with:
+          name: freeipa-server-fedora-32.tar.gz
+      - name: Push Fedora 32 image to Docker Hub
+        run: skopeo copy docker-archive:freeipa-server-fedora-32.tar.gz docker://docker.io/freipa/freeipa-server:fedora-32
+      - uses: actions/download-artifact@v2
+        with:
+          name: freeipa-server-fedora-rawhide.tar.gz
+      - name: Push Fedora rawhide image to Docker Hub
+        run: skopeo copy docker-archive:freeipa-server-fedora-rawhide.tar.gz docker://docker.io/freipa/freeipa-server:fedora-rawhide
+      - uses: actions/download-artifact@v2
+        with:
+          name: freeipa-server-centos-8.tar.gz
+      - name: Push CentOS 8 image to Docker Hub
+        run: skopeo copy docker-archive:freeipa-server-centos-8.tar.gz docker://docker.io/freipa/freeipa-server:centos-8
+      - uses: actions/download-artifact@v2
+        with:
+          name: freeipa-server-centos-7.tar.gz
+      - name: Push CentOS 7 image to Docker Hub
+        run: skopeo copy docker-archive:freeipa-server-centos-7.tar.gz docker://docker.io/freipa/freeipa-server:centos-7
+

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -171,25 +171,25 @@ jobs:
         env:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-        run: echo "$DOCKER_PASSWORD" | skopeo login -u "$DOCKER_USERNAME" --password-stdin docker.io
+        run: echo "$DOCKER_PASSWORD" | skopeo login --authfile=auth.json -u "$DOCKER_USERNAME" --password-stdin docker.io
       - uses: actions/download-artifact@v2
         with:
           name: freeipa-server-fedora-32.tar.gz
       - name: Push Fedora 32 image to Docker Hub
-        run: skopeo copy docker-archive:freeipa-server-fedora-32.tar.gz docker://docker.io/freipa/freeipa-server:fedora-32
+        run: skopeo copy --authfile=auth.json docker-archive:freeipa-server-fedora-32.tar.gz docker://docker.io/freipa/freeipa-server:fedora-32
       - uses: actions/download-artifact@v2
         with:
           name: freeipa-server-fedora-rawhide.tar.gz
       - name: Push Fedora rawhide image to Docker Hub
-        run: skopeo copy docker-archive:freeipa-server-fedora-rawhide.tar.gz docker://docker.io/freipa/freeipa-server:fedora-rawhide
+        run: skopeo copy --authfile=auth.json docker-archive:freeipa-server-fedora-rawhide.tar.gz docker://docker.io/freipa/freeipa-server:fedora-rawhide
       - uses: actions/download-artifact@v2
         with:
           name: freeipa-server-centos-8.tar.gz
       - name: Push CentOS 8 image to Docker Hub
-        run: skopeo copy docker-archive:freeipa-server-centos-8.tar.gz docker://docker.io/freipa/freeipa-server:centos-8
+        run: skopeo copy --authfile=auth.json docker-archive:freeipa-server-centos-8.tar.gz docker://docker.io/freipa/freeipa-server:centos-8
       - uses: actions/download-artifact@v2
         with:
           name: freeipa-server-centos-7.tar.gz
       - name: Push CentOS 7 image to Docker Hub
-        run: skopeo copy docker-archive:freeipa-server-centos-7.tar.gz docker://docker.io/freipa/freeipa-server:centos-7
+        run: skopeo copy --authfile=auth.json docker-archive:freeipa-server-centos-7.tar.gz docker://docker.io/freipa/freeipa-server:centos-7
 


### PR DESCRIPTION
With this change the same images that are used for tests in the master branch will be pushed to the Docker Hub.

We'd need `DOCKER_USERNAME` and `DOCKER_PASSWORD` secrets in this repository set to some account which can push to https://hub.docker.com/r/freeipa/freeipa-server. Also, the automatic builds in https://hub.docker.com/r/freeipa/freeipa-server that (I assume) are now run from https://github.com/Tiboris/freeipa-container should be disabled.

The pull request shows pushing Fedora 32, rawhide, CentOS 8 and 7 images. Based on proposal in https://github.com/freeipa/freeipa-container/issues/343#issuecomment-688650487 we do not push `:latest` here and maybe we should just delete it from the Docker Hub? I can add pushing Fedora 31 if we find it useful.

I've tested this change on my fork and https://github.com/adelton/freeipa-container/actions/runs/244114261 shows images pushed to https://hub.docker.com/r/adelton/freeipa-server/tags (I've used `.${{ github.sha }}` suffix in that test to make the pushed images easily identifiable).

@Tiboris, @abbra, please comment on the approach. I don't have access to the Docker Hub repository to make the changes myself.

If we decide that for https://github.com/freeipa/freeipa-container/issues/343 / https://github.com/freeipa/freeipa-container/issues/246 some different tagging is desired (for example with the version of FreeIPA in the container), that would be possible as well with this setup because it is easy to introspect what landed into the images. However, at this point I'm not convinced that the "dangerous for orchestrated use" is really a problem that we can reasonably solve without manual testing and promotion of images, that's why I just went to straight replacement of the existing autobuild setup and we can of course change the tagging later.