### PR TITLE
Point ipa-backup and ipa-restore log location to /data.

### DIFF
--- a/patches/ipa-data-fedora-32.patch
+++ b/patches/ipa-data-fedora-32.patch
@@ -1,3 +1,23 @@
+--- /usr/lib/python3.8/site-packages/ipaplatform/base/paths.py	2020-09-26 08:16:20.000000000 +0000
++++ /usr/lib/python3.8/site-packages/ipaplatform/base/paths.py	2020-10-25 18:08:03.666074920 +0000
+@@ -336,7 +336,7 @@
+     VAR_LOG_AUDIT = "/var/log/audit/audit.log"
+     VAR_LOG_HTTPD_DIR = "/var/log/httpd"
+     VAR_LOG_HTTPD_ERROR = "/var/log/httpd/error_log"
+-    IPABACKUP_LOG = "/var/log/ipabackup.log"
++    IPABACKUP_LOG = "/data/var/log/ipabackup.log"
+     IPACLIENT_INSTALL_LOG = "/var/log/ipaclient-install.log"
+     IPACLIENT_UNINSTALL_LOG = "/var/log/ipaclient-uninstall.log"
+     IPACLIENTSAMBA_INSTALL_LOG = "/var/log/ipaclientsamba-install.log"
+@@ -344,7 +344,7 @@
+     IPAREPLICA_CA_INSTALL_LOG = "/var/log/ipareplica-ca-install.log"
+     IPAREPLICA_CONNCHECK_LOG = "/var/log/ipareplica-conncheck.log"
+     IPAREPLICA_INSTALL_LOG = "/var/log/ipareplica-install.log"
+-    IPARESTORE_LOG = "/var/log/iparestore.log"
++    IPARESTORE_LOG = "/data/var/log/iparestore.log"
+     IPASERVER_INSTALL_LOG = "/var/log/ipaserver-install.log"
+     IPASERVER_KRA_INSTALL_LOG = "/var/log/ipaserver-kra-install.log"
+     IPASERVER_UNINSTALL_LOG = "/var/log/ipaserver-uninstall.log"
 --- /usr/lib/tmpfiles.d/var.conf	2018-10-29 00:59:14.000000000 +0000
 +++ /usr/lib/tmpfiles.d/var.conf	2018-12-14 10:37:58.607898037 +0000
 @@ -12,9 +12,9 @@

--- a/patches/ipa-data-fedora-33.patch
+++ b/patches/ipa-data-fedora-33.patch
@@ -1,3 +1,23 @@
+--- /usr/lib/python3.9/site-packages/ipaplatform/base/paths.py	2020-09-26 08:16:20.000000000 +0000
++++ /usr/lib/python3.9/site-packages/ipaplatform/base/paths.py	2020-10-25 18:08:03.666074920 +0000
+@@ -336,7 +336,7 @@
+     VAR_LOG_AUDIT = "/var/log/audit/audit.log"
+     VAR_LOG_HTTPD_DIR = "/var/log/httpd"
+     VAR_LOG_HTTPD_ERROR = "/var/log/httpd/error_log"
+-    IPABACKUP_LOG = "/var/log/ipabackup.log"
++    IPABACKUP_LOG = "/data/var/log/ipabackup.log"
+     IPACLIENT_INSTALL_LOG = "/var/log/ipaclient-install.log"
+     IPACLIENT_UNINSTALL_LOG = "/var/log/ipaclient-uninstall.log"
+     IPACLIENTSAMBA_INSTALL_LOG = "/var/log/ipaclientsamba-install.log"
+@@ -344,7 +344,7 @@
+     IPAREPLICA_CA_INSTALL_LOG = "/var/log/ipareplica-ca-install.log"
+     IPAREPLICA_CONNCHECK_LOG = "/var/log/ipareplica-conncheck.log"
+     IPAREPLICA_INSTALL_LOG = "/var/log/ipareplica-install.log"
+-    IPARESTORE_LOG = "/var/log/iparestore.log"
++    IPARESTORE_LOG = "/data/var/log/iparestore.log"
+     IPASERVER_INSTALL_LOG = "/var/log/ipaserver-install.log"
+     IPASERVER_KRA_INSTALL_LOG = "/var/log/ipaserver-kra-install.log"
+     IPASERVER_UNINSTALL_LOG = "/var/log/ipaserver-uninstall.log"
 --- /usr/lib/tmpfiles.d/var.conf	2018-10-29 00:59:14.000000000 +0000
 +++ /usr/lib/tmpfiles.d/var.conf	2018-12-14 10:37:58.607898037 +0000
 @@ -12,9 +12,9 @@

--- a/patches/ipa-data-rhel-8.patch
+++ b/patches/ipa-data-rhel-8.patch
@@ -21,6 +21,24 @@
      NAMED_RFC1912_ZONES = "/etc/named.rfc1912.zones"
      NAMED_ROOT_KEY = "/etc/named.root.key"
      NAMED_BINDKEYS_FILE = "/etc/named.iscdlv.key"
+@@ -336,7 +336,7 @@
+     VAR_LOG_AUDIT = "/var/log/audit/audit.log"
+     VAR_LOG_HTTPD_DIR = "/var/log/httpd"
+     VAR_LOG_HTTPD_ERROR = "/var/log/httpd/error_log"
+-    IPABACKUP_LOG = "/var/log/ipabackup.log"
++    IPABACKUP_LOG = "/data/var/log/ipabackup.log"
+     IPACLIENT_INSTALL_LOG = "/var/log/ipaclient-install.log"
+     IPACLIENT_UNINSTALL_LOG = "/var/log/ipaclient-uninstall.log"
+     IPACLIENTSAMBA_INSTALL_LOG = "/var/log/ipaclientsamba-install.log"
+@@ -344,7 +344,7 @@
+     IPAREPLICA_CA_INSTALL_LOG = "/var/log/ipareplica-ca-install.log"
+     IPAREPLICA_CONNCHECK_LOG = "/var/log/ipareplica-conncheck.log"
+     IPAREPLICA_INSTALL_LOG = "/var/log/ipareplica-install.log"
+-    IPARESTORE_LOG = "/var/log/iparestore.log"
++    IPARESTORE_LOG = "/data/var/log/iparestore.log"
+     IPASERVER_INSTALL_LOG = "/var/log/ipaserver-install.log"
+     IPASERVER_KRA_INSTALL_LOG = "/var/log/ipaserver-kra-install.log"
+     IPASERVER_UNINSTALL_LOG = "/var/log/ipaserver-uninstall.log"
 --- /usr/lib/python3.6/site-packages/ipaplatform/redhat/paths.py	2019-09-23 09:28:23.000000000 +0000
 +++ /usr/lib/python3.6/site-packages/ipaplatform/redhat/paths.py	2019-11-09 05:54:47.896060575 +0000
 @@ -39,7 +39,7 @@


### PR DESCRIPTION
Addressing failure in read-only containers
```
[Errno 30] Read-only file system: '/var/log/ipabackup.log'.
```

Fixes https://github.com/freeipa/freeipa-container/issues/347.

I only add the patch to the current/future OS versions because I don't consider it critical.