### PR TITLE
If resolv.conf is the same as we saw it right after installation, we likely can use it as is.

### DIFF
--- a/ipa-server-configure-first
+++ b/ipa-server-configure-first
@@ -115,7 +115,9 @@ if [ "$1" == upgrade ] ; then
 		echo "The /data volume was created using incompatible image." >&2
 		exit 2
 	fi
-	if [ -f /data/etc/resolv.conf.ipa ] && ! grep '^nameserver 127\.0\.0\.1$' /etc/resolv.conf ; then
+	if [ -f /data/etc/resolv.conf.ipa ] \
+		&& ! cmp /etc/resolv.conf /data/etc/resolv.conf.ipa \
+		&& ! grep '^nameserver 127\.0\.0\.1$' /etc/resolv.conf ; then
 		perl -pe 's/^(nameserver).*/$1 127.0.0.1/' /data/etc/resolv.conf.ipa > /etc/resolv.conf
 		if ! grep -q "\b$HOSTNAME\b" /etc/hosts ; then
 			echo "127.0.0.2 $HOSTNAME" >> /etc/hosts


### PR DESCRIPTION
This should address the issue of attempted modification of resolv.conf on read-only setups.

Fixes https://github.com/freeipa/freeipa-container/issues/413.