### PR TITLE
Enable running ipa-kra-install with read-only setup.

### DIFF
--- a/tests/run-master-and-replica.sh
+++ b/tests/run-master-and-replica.sh
@@ -136,8 +136,10 @@ elif [ "$readonly" == "--read-only" ] ; then
 	readonly_run="$readonly --dns=127.0.0.1"
 fi
 
+fresh_install=true
 if [ -f "$VOLUME/build-id" ] ; then
 	# If we were given already populated volume, just run the container
+	fresh_install=false
 	run_ipa_container $IMAGE freeipa-master exit-on-finished
 else
 	# Initial setup of the FreeIPA server
@@ -201,7 +203,10 @@ $docker exec freeipa-master bash -c 'yes Secret123 | kinit admin'
 $docker exec freeipa-master ipa user-add --first Bob --last Nowak bob$$
 $docker exec freeipa-master id bob$$
 
-$docker exec freeipa-master ipa-adtrust-install -a Secret123 --netbios-name=EXAMPLE -U
+if $fresh_install ; then
+	$docker exec freeipa-master ipa-adtrust-install -a Secret123 --netbios-name=EXAMPLE -U
+	$docker exec freeipa-master ipa-kra-install -p Secret123 -U
+fi
 )
 
 if [ "$replica" = 'none' ] ; then

--- a/volume-data-list
+++ b/volume-data-list
@@ -32,6 +32,7 @@
 /etc/yp.conf
 /root/ca-agent.p12
 /root/cacert.p12
+/root/kracert.p12
 /root/.dogtag/
 /root/ipa.csr
 /usr/share/ipa/html/ca.crt
@@ -72,6 +73,7 @@
 /var/log/ipareplica-install.log
 /var/log/ipaserver-adtrust-install.log
 /var/log/ipaserver-install.log
+/var/log/ipaserver-kra-install.log
 /var/log/ipa-server-configure-first.log
 /var/log/ipa-server-run.log
 /var/log/ipaupgrade.log


### PR DESCRIPTION
Also adding it to CI jobs in `tests/run-master-and-replica.sh`.

Fixes https://github.com/freeipa/freeipa-container/issues/471.