### PR TITLE
fix creation of /etc/pki/pki-tomcat

### DIFF
--- a/volume-data-list
+++ b/volume-data-list
@@ -22,7 +22,7 @@
 /etc/pam.d/
 /etc/pki/ca-trust/
 /etc/pki/nssdb/
-/etc/pki/pki-tomcat
+/etc/pki/pki-tomcat/
 /etc/pkcs11/modules/
 /etc/rndc.key
 /etc/samba/


### PR DESCRIPTION
- without trailing slash this directory will not be created
- CA creation fails without this directory