### PR TITLE
Ensure the centos7 build uses the vault repo

### DIFF
--- a/Dockerfile.centos-7
+++ b/Dockerfile.centos-7
@@ -1,6 +1,11 @@
 # Clone from the CentOS 7
 FROM quay.io/centos/centos:centos7
 
+# Use the vault repo since CentOS 7 is EOL 
+RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
+RUN sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+
+
 # Workaround https://bugzilla.redhat.com/show_bug.cgi?id=1941142
 COPY resolv.conf hostname /etc/
 


### PR DESCRIPTION
CentOS7 was EOL on June 30, 2024, but some of us (like me!) still need to run a container running that release. Proposed change is to replace the repos with the vault ones.