### PR TITLE
Fix ipa-server-configure-first script to work with ipv4 and ipv6 addrs

### DIFF
--- a/init-data
+++ b/init-data
@@ -202,7 +202,9 @@ if ! [ -f /etc/ipa/ca.crt ] ; then
 	fi
 	if [ -n "$IPA_SERVER_INSTALL_OPTS" ] ; then
 		if [ "$COMMAND" == 'ipa-server-install' -o "$COMMAND" = 'ipa-replica-install' ] ; then
-			echo "$IPA_SERVER_INSTALL_OPTS" >> $OPTIONS_FILE
+			for item in $IPA_SERVER_INSTALL_OPTS ; do
+				printf '%q\n' $item >> $OPTIONS_FILE
+			done
 		else
 			echo "Warning: ignoring environment variable IPA_SERVER_INSTALL_OPTS." >&2
 		fi
@@ -271,6 +273,50 @@ if [ $SHOW_LOG == 1 ] ; then
 	)
 fi
 
+function parse_ip_address () {
+	if [ $# -eq 0 ] ; then
+		echo "You need to pass argument with file path to this function"
+		exit 1
+	fi
+	if [ -f "$1" ] ; then
+		local IPS=''
+		IFS=$'\n' read -d '' -r -a lines < $1
+		for i in ${!lines[@]} ; do
+			if [[ "${lines[i]}" =~ ^'--ip-address'.*$ ]] ; then
+				# check that the parameter value is in the same line
+				if [ -n "$(echo ${lines[i]} | cut -s -d '=' -f 2)" -o -n "$(echo ${lines[i]} | cut -s -d ' ' -f 2)" ] ; then
+					if [ -z "$IPS" ] ; then
+						IPS=${lines[i]:13}
+						continue
+					fi
+					IPS="${IPS} ${lines[i]:13}"
+					continue
+				fi
+				if [ -z "$IPS" ] ; then
+					IPS=${lines[i+1]}
+					continue
+				fi
+				IPS="$IPS ${lines[i+1]}"
+			fi
+		done
+		unset IFS
+		echo "$IPS"
+	fi
+}
+
+IPA_SERVER_IPS=''
+IPA_SERVER_IPS=$(parse_ip_address $DATA_OPTIONS_FILE)
+RUN_IPA_SERVER_IPS=$(parse_ip_address $OPTIONS_FILE)
+
+if [ -n "$RUN_IPA_SERVER_IPS" ] ; then
+	IPA_SERVER_IPS=$RUN_IPA_SERVER_IPS
+fi
+
+if [ -n "$IPA_SERVER_IPS" ] ; then
+	echo "$IPA_SERVER_IPS" > /run/ipa/ipa-server-ip
+fi
+
+# for compatibility with oldest freeipa versions
 if [ -n "$IPA_SERVER_IP" ] ; then
 	echo "$IPA_SERVER_IP" > /run/ipa/ipa-server-ip
 fi

--- a/ipa-server-configure-first
+++ b/ipa-server-configure-first
@@ -29,31 +29,40 @@ test ! -f /run/ipa/debug-trace || set -x
 HOSTNAME=$( cat /data/hostname )
 
 function update_server_ip_address () {
-	CURRENT_IP=$( dig +short -t A $HOSTNAME )
+	CURRENT_IP="$( dig +short -t A $HOSTNAME ) $( dig +short -t AAAA $HOSTNAME )"
+	CURRENT_IP=$(echo $CURRENT_IP | xargs -n1 | sort | xargs)
 	MY_IP=''
 	if [ -f /run/ipa/ipa-server-ip ] ; then
 		MY_IP=$( cat /run/ipa/ipa-server-ip )
-		if [ "$CURRENT_IP" == "$MY_IP" ] ; then
+		if [ "$CURRENT_IP" == "$(echo $MY_IP | xargs -n1 | sort | xargs)" ] ; then
 			return
 		fi
 	else
-		for i in $( /sbin/ip addr show | awk '/inet .*global/ { split($2,a,"/"); print a[1]; }' ) ; do
-			if [ "$CURRENT_IP" == "$i" ] ; then
-				return
-			fi
-			if [ -z "$MY_IP" ] ; then
-				MY_IP="$i"
-			fi
-		done
+		INTERFACES_IPS=$( /sbin/ip addr show | awk '/inet(6?) .*global/ { split($2,a,"/"); print a[1]; }' )
+		INTERFACES_IPS=$(echo $INTERFACES_IPS | xargs -n1 | sort | xargs)
+		if [ "$INTERFACES_IPS" == "$CURRENT_IP" ] ; then
+			return
+		fi
+		MY_IP="$INTERFACES_IPS"
 	fi
 
 	kdestroy -A
 	kinit -k
 	(
-		echo "update add $HOSTNAME 180 A $MY_IP"
+		for m in $MY_IP ; do
+			DNS_TYPE_RECORD='A'
+			if [[ "$m" =~ ^([0-9a-fA-F]{0,4}:){1,7}[0-9a-fA-F]{0,4}$ ]] ; then
+				DNS_TYPE_RECORD='AAAA'
+			fi
+			echo "update add $HOSTNAME 180 $DNS_TYPE_RECORD $m"
+		done
 		for i in $CURRENT_IP ; do
-			if [ "$i" != "$MY_IP" ] ; then
-				echo "update delete $HOSTNAME A $i"
+			DNS_TYPE_RECORD='A'
+			if [[ "$i" =~ ^([0-9a-fA-F]{0,4}:){1,7}[0-9a-fA-F]{0,4}$ ]] ; then
+				DNS_TYPE_RECORD='AAAA'
+			fi
+			if [[ ! "$MY_IP" =~ "$i" ]] ; then
+				echo "update delete $HOSTNAME $DNS_TYPE_RECORD $i"
 			fi
 		done
 		echo "send"
@@ -62,8 +71,9 @@ function update_server_ip_address () {
 	kdestroy -A
 
 	while true ; do
-		NEW_IP=$( dig +short -t A $HOSTNAME )
-		if [ "$NEW_IP" == "$MY_IP" ] ; then
+		NEW_IP="$( dig +short -t A $HOSTNAME ) $( dig +short -t AAAA $HOSTNAME )"
+		NEW_IP=$(echo $NEW_IP | xargs -n1 | sort | xargs)
+		if [ "$NEW_IP" == "$(echo $MY_IP | xargs -n1 | sort | xargs)" ] ; then
 			break
 		fi
 		sleep 1
@@ -73,7 +83,7 @@ function update_server_ip_address () {
 function wait_for_dns () {
 	local TIMEOUT="$1"
 	local WAIT_UNTIL="$((SECONDS + TIMEOUT))"
-	while ! host -t A $HOSTNAME > /dev/null ; do
+	while ! (host -t A $HOSTNAME > /dev/null && host -t AAAA $HOSTNAME > /dev/null) ; do
 		if [[ "$SECONDS" -lt "$WAIT_UNTIL" ]]; then
 			sleep 1
 			continue

--- a/tests/run-master-and-replica.sh
+++ b/tests/run-master-and-replica.sh
@@ -229,7 +229,7 @@ $docker rm -f freeipa-master
 $sudo mv $VOLUME/build-id $VOLUME/build-id.initial
 uuidgen | $sudo tee $VOLUME/build-id
 $sudo touch -r $VOLUME/build-id.initial $VOLUME/build-id
-run_ipa_container $IMAGE freeipa-master
+run_ipa_container $IMAGE freeipa-master $dns_opts
 
 # Wait for the services to start to the point when SSSD is operational
 for i in $( seq 1 20 ) ; do


### PR DESCRIPTION
Сontinuing work on pull request https://github.com/freeipa/freeipa-container/pull/617
Parsing `--ip-address` option from server-install or replica-install options instead of using environment variable
Update configure-first script to work in dual stack mode
Fix rootless podman tests