### PR TITLE
Add support for -e IPA_SERVER_IP=no-update.

### DIFF
--- a/README
+++ b/README
@@ -292,11 +292,18 @@ and also use the `--add-host` option to the `docker run` / `podman run`
 with the same IP address, especially when running the container
 as read only.
 
-Alternatively, the `IPA_SERVER_IP` environment variable via the
-`-e` option to `docker run` / `podman run` can be used to
-define what IP address should the FreeIPA server put to DNS as its
-address. Using this mechanism will however not update the `ipa-ca`
-record.
+By default the container will attempt to update the FreeIPA
+server's IPv4 address in the internal DNS server to its internal
+address (as seen in the container) upon each startup, using the
+systemd service `ipa-server-update-self-ip-address` in the container.
+You can disable this mechanism by setting the `IPA_SERVER_IP`
+environment variable to `no-update`, via the `-e` option to
+`docker run` / `podman run`, or by exec-ing to the container and running
+`systemctl disable ipa-server-update-self-ip-address.service`.
+
+Alternatively, the `IPA_SERVER_IP` environment variable can be
+used to force the IPv4 address DNS record to a specific value.
+Using this mechanism will however not update the `ipa-ca` record.
 
 ## Debugging
 

--- a/ipa-server-configure-first
+++ b/ipa-server-configure-first
@@ -27,6 +27,10 @@ set -e
 test ! -f /run/ipa/debug-trace || set -x
 
 HOSTNAME=$( cat /data/hostname )
+IPA_SERVER_IP=
+if [ -f /run/ipa/ipa-server-ip ] ; then
+	IPA_SERVER_IP=$( cat /run/ipa/ipa-server-ip )
+fi
 
 function update_server_ip_address () {
 	CURRENT_IP=$( dig +short -t A $HOSTNAME )
@@ -87,7 +91,9 @@ if [ "$1" == update-self-ip-address ] ; then
 	exec >> /var/log/ipa-server-run.log 2>&1
 	echo "$(date) $0 $@"
 
-	if systemctl is-active -q named named-pkcs11 || [ -f /run/ipa/ipa-server-ip ] ; then
+	if [ "$IPA_SERVER_IP" == no-update ] ; then
+		echo "FreeIPA server IP address update disabled, skipping update-self-ip-address."
+	elif systemctl is-active -q named named-pkcs11 || [ -n "$IPA_SERVER_IP" ] ; then
 		# Wait until DNS is up and running and resolving
 		if wait_for_dns 60; then
 			update_server_ip_address
@@ -224,7 +230,7 @@ else
 			exit
 		fi
 
-		if systemctl is-active -q named named-pkcs11 || [ -f /run/ipa/ipa-server-ip ] ; then
+		if [ "$IPA_SERVER_IP" != no-update ] && ( systemctl is-active -q named named-pkcs11 || [ -n "$IPA_SERVER_IP" ] ) ; then
 			cp -f /etc/resolv.conf /data/etc/resolv.conf.ipa
 			if wait_for_dns 180; then
 				update_server_ip_address

--- a/tests/freeipa-k3s.yaml
+++ b/tests/freeipa-k3s.yaml
@@ -103,7 +103,7 @@ spec:
     - name: IPA_SERVER_INSTALL_OPTS
       value: "-U -r CLUSTER.LOCAL --setup-dns --no-forwarders --no-ntp --ip-address=10.43.201.201"
     - name: IPA_SERVER_IP
-      value: 10.43.201.201
+      value: no-update
     readinessProbe:
       exec:
         command: [ "/usr/bin/systemctl", "status", "ipa" ]

--- a/tests/freeipa-replica-k3s.yaml
+++ b/tests/freeipa-replica-k3s.yaml
@@ -96,7 +96,7 @@ spec:
           name: freeipa-server-password
           key: admin.password
     - name: IPA_SERVER_IP
-      value: 10.43.202.202
+      value: no-update
     readinessProbe:
       exec:
         command: [ "/usr/bin/systemctl", "status", "ipa" ]


### PR DESCRIPTION
When an IPv4 address is set using the `ipa-server-install`'s `--ip-address` parameter and the DNS record gets populated with that value, the current logic in `ipa-server-configure-first` rewrites that value after the `ipa-server-install` finishes and then during the subsequent container starts with the current internal IPv4 address of the container. Admins then have to use the `IPA_SERVER_IP` environment variable to force the value to be left alone.

This PR adds support for `IPA_SERVER_IP` value `no-update`, to just leave the DNS records alone during the container startup.

That way, whatever value(s) get set either during the initial `ipa-server-install` or perhaps manually will not get lost.