### PR TITLE
fix log message on freeipa first start when enable no-update

### DIFF
--- a/ipa-server-configure-first
+++ b/ipa-server-configure-first
@@ -229,8 +229,9 @@ else
 			systemctl poweroff
 			exit
 		fi
-
-		if [ "$IPA_SERVER_IP" != no-update ] && ( systemctl is-active -q named named-pkcs11 || [ -n "$IPA_SERVER_IP" ] ) ; then
+		if [ "$IPA_SERVER_IP" == no-update ] ; then
+			echo "FreeIPA server IP address update disabled, skipping update-self-ip-address."
+		elif ( systemctl is-active -q named named-pkcs11 || [ -n "$IPA_SERVER_IP" ] ) ; then
 			cp -f /etc/resolv.conf /data/etc/resolv.conf.ipa
 			if wait_for_dns 180; then
 				update_server_ip_address


### PR DESCRIPTION
Hi!
I tested PR https://github.com/freeipa/freeipa-container/pull/640 and saw a not quite correct message during the first freeipa server initialization with the variable IPA_SERVER_IP=no-update
Here is my fixes