### PR TITLE
No longer update `resolv.conf` to point to our own DNS server, let users specify the `--dns=127.0.0.1` explicitly [deprecate first].

### DIFF
--- a/README
+++ b/README
@@ -264,11 +264,8 @@ If you receive error like
 
 you might need to use `ipa-server-install` option `--skip-mem-check`.
 
-When running DNS server (the `--setup-dns` argument to
-`ipa-server-install`) in a container with read-only root filesystem
-(the `--read-only` option to `podman run` or `docker run`), the setup
-code in the container won't be able to edit `/etc/resolv.conf` in the
-container to point it to itself. Add `--dns=127.0.0.1` option to the
+When running DNS server (the `--setup-dns` argument to `ipa-server-install`)
+in the FreeIPA container, add `--dns=127.0.0.1` option to the
 `podman run` or `docker run` invocation to allow the FreeIPA server
 to reach its own DNS server.
 

--- a/ipa-server-configure-first
+++ b/ipa-server-configure-first
@@ -143,6 +143,9 @@ if [ "$1" == upgrade ] ; then
 		if ! grep -q "\b$HOSTNAME\b" /etc/hosts ; then
 			echo "127.0.0.2 $HOSTNAME" >> /etc/hosts
 		fi
+		echo "NOTE:" >&2
+		echo "Consider setting --dns=127.0.0.1 when using internal DNS server." >&2
+		echo "The mechanism which sets it now will be removed from images in April 2025." >&2
 	fi
 	# Removing kdcinfo.* which is likely to hold old IP address
 	rm -rf /var/lib/sss/pubconf/kdcinfo.*
@@ -207,6 +210,11 @@ else
 		usage "The container has to have fully-qualified hostname defined."
 	fi
 
+	resolv_conf_has_localhost=false
+	if grep '^nameserver 127\.0\.0\.1$' /etc/resolv.conf ; then
+		resolv_conf_has_localhost=true
+	fi
+
 	STDIN=/dev/stdin
 	STDOUT=/dev/stdout
 	STDERR=/dev/stderr
@@ -231,13 +239,18 @@ else
 		fi
 		if [ "$IPA_SERVER_IP" == no-update ] ; then
 			echo "FreeIPA server IP address update disabled, skipping update-self-ip-address."
-		elif ( systemctl is-active -q named named-pkcs11 || [ -n "$IPA_SERVER_IP" ] ) ; then
+		elif systemctl is-active -q named named-pkcs11 || [ -n "$IPA_SERVER_IP" ] ; then
 			cp -f /etc/resolv.conf /data/etc/resolv.conf.ipa
 			if wait_for_dns 180; then
 				update_server_ip_address
 			else
 				echo "Unable to resolve \"${HOSTNAME}\". Is --dns=127.0.0.1 set for the container?" >&2
 				exit 2
+			fi
+			if systemctl is-active -q named named-pkcs11 && ! $resolv_conf_has_localhost ; then
+				echo "NOTE:" >&2
+				echo "Consider setting --dns=127.0.0.1 when using internal DNS server." >&2
+				echo "The mechanism which sets it now will be removed from images in April 2025." >&2
 			fi
 		else
 			echo "FreeIPA server does not run DNS server, skipping update-self-ip-address."

--- a/tests/run-master-and-replica.sh
+++ b/tests/run-master-and-replica.sh
@@ -133,7 +133,7 @@ function run_ipa_container() {
 	(
 	set -x
 	umask 0
-	$docker run $readonly_run -d --name "$N" $OPTS \
+	$docker run -d --name "$N" $OPTS \
 		-v $VOLUME:/data:Z $DOCKER_RUN_OPTS \
 		-e PASSWORD=Secret123 "$IMAGE" "$@"
 	)
@@ -142,9 +142,9 @@ function run_ipa_container() {
 
 IMAGE="$1"
 
-readonly_run="$readonly"
+DOCKER_RUN_OPTS="--dns=127.0.0.1"
 if [ "$readonly" == "--read-only" ] ; then
-	readonly_run="$readonly --dns=127.0.0.1"
+	DOCKER_RUN_OPTS="$DOCKER_RUN_OPTS --read-only"
 fi
 
 skip_opts=
@@ -238,9 +238,11 @@ if [ "$replica" = 'none' ] ; then
 fi
 
 # Setup replica
-readonly_run="$readonly"
 MASTER_IP=$( $docker inspect --format '{{ .NetworkSettings.IPAddress }}' freeipa-master )
 DOCKER_RUN_OPTS="--dns=$MASTER_IP"
+if [ "$readonly" == "--read-only" ] ; then
+	DOCKER_RUN_OPTS="$DOCKER_RUN_OPTS --read-only"
+fi
 if [ "$docker" != "sudo podman" -a "$docker" != "podman" ] ; then
 	DOCKER_RUN_OPTS="--link freeipa-master:ipa.example.test $DOCKER_RUN_OPTS"
 fi


### PR DESCRIPTION
Initial deprecation message for https://github.com/freeipa/freeipa-container/issues/644.