### PR TITLE
No longer update `resolv.conf` to point to our own DNS server, let users specify the `--dns=127.0.0.1` explicitly.

### DIFF
--- a/ipa-server-configure-first
+++ b/ipa-server-configure-first
@@ -136,17 +136,6 @@ if [ "$1" == upgrade ] ; then
 		echo "The /data volume was created using incompatible image." >&2
 		exit 2
 	fi
-	if [ -f /data/etc/resolv.conf.ipa ] \
-		&& ! cmp /etc/resolv.conf /data/etc/resolv.conf.ipa \
-		&& ! grep '^nameserver 127\.0\.0\.1$' /etc/resolv.conf ; then
-		perl -pe 's/^(nameserver).*/$1 127.0.0.1/' /data/etc/resolv.conf.ipa > /etc/resolv.conf
-		if ! grep -q "\b$HOSTNAME\b" /etc/hosts ; then
-			echo "127.0.0.2 $HOSTNAME" >> /etc/hosts
-		fi
-		echo "NOTE:" >&2
-		echo "Consider setting --dns=127.0.0.1 when using internal DNS server." >&2
-		echo "The mechanism which sets it now will be removed from images in April 2025." >&2
-	fi
 	# Removing kdcinfo.* which is likely to hold old IP address
 	rm -rf /var/lib/sss/pubconf/kdcinfo.*
 	if cmp /data/build-id /data-template/build-id ; then
@@ -210,11 +199,6 @@ else
 		usage "The container has to have fully-qualified hostname defined."
 	fi
 
-	resolv_conf_has_localhost=false
-	if grep '^nameserver 127\.0\.0\.1$' /etc/resolv.conf ; then
-		resolv_conf_has_localhost=true
-	fi
-
 	STDIN=/dev/stdin
 	STDOUT=/dev/stdout
 	STDERR=/dev/stderr
@@ -240,17 +224,11 @@ else
 		if [ "$IPA_SERVER_IP" == no-update ] ; then
 			echo "FreeIPA server IP address update disabled, skipping update-self-ip-address."
 		elif systemctl is-active -q named named-pkcs11 || [ -n "$IPA_SERVER_IP" ] ; then
-			cp -f /etc/resolv.conf /data/etc/resolv.conf.ipa
 			if wait_for_dns 180; then
 				update_server_ip_address
 			else
 				echo "Unable to resolve \"${HOSTNAME}\". Is --dns=127.0.0.1 set for the container?" >&2
 				exit 2
-			fi
-			if systemctl is-active -q named named-pkcs11 && ! $resolv_conf_has_localhost ; then
-				echo "NOTE:" >&2
-				echo "Consider setting --dns=127.0.0.1 when using internal DNS server." >&2
-				echo "The mechanism which sets it now will be removed from images in April 2025." >&2
 			fi
 		else
 			echo "FreeIPA server does not run DNS server, skipping update-self-ip-address."


### PR DESCRIPTION
Fixes https://github.com/freeipa/freeipa-container/issues/644.

In https://github.com/freeipa/freeipa-container/pull/646 we added a note that the current mechanism will be removed in April 2025. This is the removal, so this PR should be rebased and pushed to master in April.