### PR TITLE
The /etc/systemd/system.conf in latest Fedoras no longer has the [Manager] section

### DIFF
--- a/DefaultLimitNOFILE.conf
+++ b/DefaultLimitNOFILE.conf
@@ -1,0 +1,2 @@
+[Manager]
+DefaultLimitNOFILE=1024

--- a/Dockerfile.almalinux-9
+++ b/Dockerfile.almalinux-9
@@ -20,7 +20,7 @@ RUN systemctl mask rpc-gssd.service
 ENV container oci
 
 # Establish reasonably low open files limit in the container
-RUN echo "DefaultLimitNOFILE=1024" >> /etc/systemd/system.conf
+COPY DefaultLimitNOFILE.conf /usr/lib/systemd/system.conf.d/DefaultLimitNOFILE.conf
 
 ENTRYPOINT [ "/usr/sbin/init" ]
 STOPSIGNAL RTMIN+3

--- a/Dockerfile.centos-9-stream
+++ b/Dockerfile.centos-9-stream
@@ -20,7 +20,7 @@ RUN systemctl mask rpc-gssd.service
 ENV container oci
 
 # Establish reasonably low open files limit in the container
-RUN echo "DefaultLimitNOFILE=1024" >> /etc/systemd/system.conf
+COPY DefaultLimitNOFILE.conf /usr/lib/systemd/system.conf.d/DefaultLimitNOFILE.conf
 
 ENTRYPOINT [ "/usr/sbin/init" ]
 STOPSIGNAL RTMIN+3

--- a/Dockerfile.fedora-40
+++ b/Dockerfile.fedora-40
@@ -24,7 +24,7 @@ RUN systemctl mask rpc-gssd.service
 # debug: RUN test "$container" = oci
 
 # Establish reasonably low open files limit in the container
-RUN echo "DefaultLimitNOFILE=1024" >> /etc/systemd/system.conf
+COPY DefaultLimitNOFILE.conf /usr/lib/systemd/system.conf.d/DefaultLimitNOFILE.conf
 
 ENTRYPOINT [ "/usr/sbin/init" ]
 STOPSIGNAL RTMIN+3

--- a/Dockerfile.fedora-41
+++ b/Dockerfile.fedora-41
@@ -32,7 +32,7 @@ RUN ( echo '[Service]' ; echo 'ExecStartPre=' ; sed '/ExecStartPre/!d; s/-R/-R -
 # debug: RUN test "$container" = oci
 
 # Establish reasonably low open files limit in the container
-RUN echo "DefaultLimitNOFILE=1024" >> /etc/systemd/system.conf
+COPY DefaultLimitNOFILE.conf /usr/lib/systemd/system.conf.d/DefaultLimitNOFILE.conf
 
 ENTRYPOINT [ "/usr/sbin/init" ]
 STOPSIGNAL RTMIN+3

--- a/Dockerfile.fedora-rawhide
+++ b/Dockerfile.fedora-rawhide
@@ -34,7 +34,7 @@ RUN ( echo '[Service]' ; echo 'ExecStartPre=' ; sed '/ExecStartPre/!d; s/-R/-R -
 # debug: RUN test "$container" = oci
 
 # Establish reasonably low open files limit in the container
-RUN echo "DefaultLimitNOFILE=1024" >> /etc/systemd/system.conf
+COPY DefaultLimitNOFILE.conf /usr/lib/systemd/system.conf.d/DefaultLimitNOFILE.conf
 
 ENTRYPOINT [ "/usr/sbin/init" ]
 STOPSIGNAL RTMIN+3

--- a/Dockerfile.rhel-9
+++ b/Dockerfile.rhel-9
@@ -19,7 +19,7 @@ RUN systemctl mask rpc-gssd.service
 # debug: RUN test "$container" = oci
 
 # Establish reasonably low open files limit in the container
-RUN echo "DefaultLimitNOFILE=1024" >> /etc/systemd/system.conf
+COPY DefaultLimitNOFILE.conf /usr/lib/systemd/system.conf.d/DefaultLimitNOFILE.conf
 
 ENTRYPOINT [ "/usr/sbin/init" ]
 STOPSIGNAL RTMIN+3

--- a/Dockerfile.rocky-9
+++ b/Dockerfile.rocky-9
@@ -23,7 +23,7 @@ RUN systemctl mask rpc-gssd.service
 ENV container oci
 
 # Establish reasonably low open files limit in the container
-RUN echo "DefaultLimitNOFILE=1024" >> /etc/systemd/system.conf
+COPY DefaultLimitNOFILE.conf /usr/lib/systemd/system.conf.d/DefaultLimitNOFILE.conf
 
 ENTRYPOINT [ "/usr/sbin/init" ]
 STOPSIGNAL RTMIN+3


### PR DESCRIPTION
Using a drop-in file seems like the cleanest approach.

Addressing
```
/etc/systemd/system.conf:1: Assignment outside of section. Ignoring.
```

Fixes https://github.com/freeipa/freeipa-container/issues/652.