### PR TITLE
Add the ARM architecture to the build and test matrix.

### DIFF
--- a/.github/build-test-params.yaml
+++ b/.github/build-test-params.yaml
@@ -19,6 +19,8 @@ run:
     "": null
   count: 15
   exclude:
+    - arch: arm64
+      runs-on: ubuntu-22.04
     # Workaround https://github.com/freeipa/freeipa-container/issues/660
     - runtime: sudo podman
       runs-on: ubuntu-22.04
@@ -44,6 +46,9 @@ test-upgrade:
     rocky-8:
       - centos-8-certs-updated-data
   count: 7
+  exclude:
+    - arch: arm64
+      runs-on: ubuntu-22.04
 
 k8s:
   runs-on:
@@ -57,10 +62,14 @@ k8s:
     docker: 1
   count: 13
   exclude:
+    - arch: arm64
+      runs-on: ubuntu-22.04
     - kubernetes: kubeadm init
       runtime: docker
 
 push:
   exclude:
     - os: centos-10-stream
+    - os: fedora-41
+      arch: arm64
 

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -10,13 +10,24 @@ on:
 jobs:
   build:
     name: Build image
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04${{ (matrix.arch == 'arm64' && '-arm') || (matrix.arch == 'x86_64' && '') }}
     strategy:
       fail-fast: false
       matrix:
         os: [ fedora-rawhide, fedora-41, fedora-40, centos-10-stream, centos-9-stream, rocky-9, rocky-8, almalinux-9, almalinux-8 ]
-        arch: [ x86_64 ]
+        arch: [ x86_64, arm64 ]
         docker: [ docker ]
+        exclude:
+          - os: fedora-40
+            arch: arm64
+          - os: centos-10-stream
+            arch: x86_64
+          - os: centos-9-stream
+            arch: arm64
+          - os: almalinux-8
+            arch: arm64
+          - os: rocky-8
+            arch: arm64
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
@@ -149,7 +160,7 @@ jobs:
 
   master-and-replica:
     name: Run
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.runs-on }}${{ (matrix.arch == 'arm64' && '-arm') || (matrix.arch == 'x86_64' && '') }}
     needs: [ build, test-plan ]
     strategy:
       fail-fast: false
@@ -176,7 +187,7 @@ jobs:
           }
           EOT
           sudo systemctl restart apparmor.service
-        if: matrix.runs-on == 'ubuntu-24.04' && matrix.runtime == 'docker rootless'
+        if: startsWith(matrix.runs-on, 'ubuntu-24.04') && matrix.runtime == 'docker rootless'
       - run: curl -fsSL https://get.docker.com/rootless | FORCE_ROOTLESS_INSTALL=1 sh
         if: matrix.runtime == 'docker rootless'
       - name: Install podman 4.*
@@ -200,7 +211,7 @@ jobs:
 
   test-upgrade:
     name: Upgrade
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.runs-on }}${{ (matrix.arch == 'arm64' && '-arm') || (matrix.arch == 'x86_64' && '') }}
     needs: [ build, test-plan ]
     strategy:
       fail-fast: false
@@ -234,7 +245,7 @@ jobs:
 
   test-k8s:
     name: Run in K8s
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.runs-on }}${{ (matrix.arch == 'arm64' && '-arm') || (matrix.arch == 'x86_64' && '') }}
     needs: [ build, test-plan ]
     strategy:
       fail-fast: false

--- a/.github/workflows/run-partial-tests.yaml
+++ b/.github/workflows/run-partial-tests.yaml
@@ -25,6 +25,7 @@ on:
         type: choice
         options:
           - ubuntu-24.04
+          - ubuntu-24.04-arm
           - ubuntu-22.04
 
 jobs:

--- a/.github/workflows/test-rhel.yaml
+++ b/.github/workflows/test-rhel.yaml
@@ -22,7 +22,7 @@ jobs:
 
   build-test-rhel-podman:
     name: Build and test RHEL image
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm
     needs: [ test-subscription ]
     if: needs.test-subscription.outputs.has_rhel_subscriptions == 1
     strategy:


### PR DESCRIPTION
I believe that through a series of changes to the test setup in `master` we now have a baseline for being able to add additional architecture to the mix beyond x86_64, namely ARM64 (aarch64). Based on announcement in https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/, ARM64 runners are now available so building and testing ARM64 images and combining them into multiarch images (manifests) from a single workflow is now possible.

In this PR I show how we could build and run tests on ARM64 on a subset of architectures, while only pushing to registries multiarch images based on AlmaLinux 9 and Rocky Linux 9. My reason for being conservative with the set of OSes that we would publish is maintenance effort, utility, and not wasting resources with excessive sets of images that folks wouldn't use anyway.

While I tested the approach manually on a separate registry repo, we shall only see if it works for real once it lands in `master` and the `push-after-success` job in the GitHub Actions workflow is run.

Comments are welcome.