### PR TITLE
Draft: Test with K3s 1.33 which already has the UserNamespacesSupport feature gate set

### DIFF
--- a/.github/actions/install-k3s/action.yaml
+++ b/.github/actions/install-k3s/action.yaml
@@ -3,21 +3,14 @@ runs:
   using: composite
   steps:
     - run: |
+        export INSTALL_K3S_CHANNEL=latest
         export INSTALL_K3S_EXEC
         if [ -e /var/run/crio/crio.sock ] ; then
-            INSTALL_K3S_EXEC="--container-runtime-endpoint /var/run/crio/crio.sock \
-                  --kubelet-arg feature-gates=UserNamespacesSupport=true \
-                  --kube-apiserver-arg feature-gates=UserNamespacesSupport=true \
-                  --kube-controller-manager-arg feature-gates=UserNamespacesSupport=true \
-                  --kube-scheduler-arg feature-gates=UserNamespacesSupport=true"
+            INSTALL_K3S_EXEC="--container-runtime-endpoint /var/run/crio/crio.sock"
         elif [ -e /var/run/docker.sock ] ; then
             INSTALL_K3S_EXEC="--docker --kubelet-arg=allowed-unsafe-sysctls=net.ipv6.conf.all.disable_ipv6"
         elif [ -e /var/run/containerd/containerd.sock ] ; then
-            INSTALL_K3S_EXEC="--container-runtime-endpoint /var/run/containerd/containerd.sock \
-                  --kubelet-arg feature-gates=UserNamespacesSupport=true \
-                  --kube-apiserver-arg feature-gates=UserNamespacesSupport=true \
-                  --kube-controller-manager-arg feature-gates=UserNamespacesSupport=true \
-                  --kube-scheduler-arg feature-gates=UserNamespacesSupport=true"
+            INSTALL_K3S_EXEC="--container-runtime-endpoint /var/run/containerd/containerd.sock"
             cat tests/containerd-2.1-config-k3s.toml | sudo tee -a /etc/containerd/config.toml
             sudo systemctl restart containerd
         fi

--- a/.github/build-test-params.yaml
+++ b/.github/build-test-params.yaml
@@ -17,7 +17,7 @@ run:
   volume:
     freeipa-data: 1
     "": null
-  count: 13
+  count: 1
   exclude:
     - arch: arm64
       runs-on: ubuntu-22.04
@@ -60,7 +60,7 @@ test-upgrade:
       - centos-8-4.8.7
     rocky-8:
       - centos-8-4.8.7
-  count: 11
+  count: 1
   exclude:
     - arch: arm64
       runs-on: ubuntu-22.04

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -10,16 +10,8 @@ on:
         description: OS / Dockerfile
         type: choice
         options:
-          - all
-          - fedora-rawhide
-          - fedora-42
-          - fedora-41
-          - almalinux-10
-          - almalinux-9
-          - almalinux-8
           - rocky-9
-          - rocky-8
-          - centos-9-stream
+          - almalinux-10
   schedule:
     - cron: '15 4 * * 1,3,5'
 


### PR DESCRIPTION
We test with `export INSTALL_K3S_CHANNEL=latest` here to get the 1.33.

Once https://github.com/k3s-io/k3s/commits/master/channel.yaml shows 1.33 is in the `stable` channel, this line should be removed.