### PR TITLE
Revert "Workaround https://github.com/freeipa/freeipa-container/issues/717."

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -55,6 +55,7 @@ jobs:
         docker: [ docker ]
         exclude:
           - os: centos-10-stream
+            arch: x86_64
           - os: centos-9-stream
             arch: arm64
           - os: almalinux-8


### PR DESCRIPTION
This reverts commit 47563a28f9d06b6e472d7d4bbe4ad50190fe451d.

Issue was resolved by 389-ds-base-3.2.0-6.el10.

Fixes https://github.com/freeipa/freeipa-container/issues/717.