### PR TITLE
Stop the scheduled / cron workflow runs on forked repositories.

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -30,6 +30,7 @@ jobs:
     name: Process workflow inputs
     runs-on: ubuntu-latest
     timeout-minutes: 1
+    if: github.event_name != 'schedule' || github.repository == 'freeipa/freeipa-container'
     outputs:
       os: ${{ steps.generate-os-list-dispatch-one.outputs.os }}${{ steps.generate-os-list-all.outputs.os }}
     steps:
@@ -152,6 +153,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [ build ]
     timeout-minutes: 1
+    if: github.event_name != 'schedule' || github.repository == 'freeipa/freeipa-container'
     outputs:
       matrix-run: ${{ steps.produce-matrix.outputs.matrix-run }}
       matrix-test-upgrade: ${{ steps.produce-matrix.outputs.matrix-test-upgrade }}

--- a/.github/workflows/run-partial-tests.yaml
+++ b/.github/workflows/run-partial-tests.yaml
@@ -31,6 +31,7 @@ jobs:
   gen-matrix:
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    if: github.event_name != 'schedule' || github.repository == 'freeipa/freeipa-container'
     outputs:
       matrix: ${{ steps.dispatch-matrix.outputs.matrix }}${{ steps.default-matrix.outputs.matrix }}
     steps:
@@ -59,6 +60,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.gen-matrix.outputs.matrix) }}
+    if: github.event_name != 'schedule' || github.repository == 'freeipa/freeipa-container'
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/test-rhel.yaml
+++ b/.github/workflows/test-rhel.yaml
@@ -10,6 +10,7 @@ jobs:
     # Workaround https://github.com/actions/runner/issues/1138
     name: Prerequisite for RHEL builds
     runs-on: ubuntu-latest
+    if: github.event_name != 'schedule' || github.repository == 'freeipa/freeipa-container'
     timeout-minutes: 1
     outputs:
       has_rhel_subscriptions: ${{ steps.check.outputs.has_rhel_subscriptions }}


### PR DESCRIPTION
Since the GitHub Actions syntax does not allow the condition to be set on the `on.schedule` elements of the workflow and it needs to be done on the `jobs.*`, the workflow runs will still be scheduled, just marked fairly quickly as skipped.

In case I'm not the only one with GitHub Actions enabled on my fork and this change might affect other people, please speak up.