### PR TITLE
We can skip the iptables requirement both on Ubuntu 26.04 and 24.04.

### DIFF
--- a/.github/actions/install-docker-rootless/action.yaml
+++ b/.github/actions/install-docker-rootless/action.yaml
@@ -18,7 +18,7 @@ runs:
         EOT
         sudo systemctl restart apparmor.service
 
-        curl -fsSL https://get.docker.com/rootless | FORCE_ROOTLESS_INSTALL=1 sh
+        curl -fsSL https://get.docker.com/rootless | FORCE_ROOTLESS_INSTALL=1 SKIP_IPTABLES=1 sh
 
         docker info --format '{{ .ClientInfo.Context }}' | grep rootless
       shell: bash -euxo pipefail {0}


### PR DESCRIPTION
Addressing Ubuntu 26.04 failure
```
# Missing system requirements. Please run following commands to # install the requirements and run this installer again. # Alternatively iptables checks can be disabled with SKIP_IPTABLES=1

cat <<EOF | sudo sh -x

modprobe ip_tables
EOF
```

Resolves https://github.com/freeipa/freeipa-container/issues/733.