### PR TITLE
Configure podman 5 on Ubuntu 26.04 to use NAT-ed pasta bridge.

### DIFF
--- a/.github/workflows/run-partial-tests.yaml
+++ b/.github/workflows/run-partial-tests.yaml
@@ -66,6 +66,8 @@ jobs:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/docker-cgroups-ubuntu-22
         if: matrix.docker == 'docker'
+      - run: mkdir -p ~/.config/containers && cp ci/containers-podman-5.conf ~/.config/containers/containers.conf
+        if: matrix.docker == 'podman'
       - name: For RHEL builds, use entitlements
         if: ${{ startsWith(matrix.os, 'rhel-') }}
         uses: ./.github/actions/podman-entitlement

--- a/ci/containers-podman-5.conf
+++ b/ci/containers-podman-5.conf
@@ -1,0 +1,3 @@
+# https://blog.podman.io/2024/03/podman-5-0-breaking-changes-in-detail/
+[network]
+pasta_options = ["-a", "10.0.2.0", "-n", "24", "-g", "10.0.2.2", "--dns-forward", "10.0.2.3"]


### PR DESCRIPTION
Addressing
```
The ipa-server-install command failed, exception:
ScriptError: The host name ipa.example.test does not match the primary host name runnervmrd89b.dtyrjvhj1jdubpegzc4liecpve.ex.internal.cloudapp.net.
```
when running
```
docker=podman tests/run-partial-tests.sh Dockerfile....
```
because by default `/etc/hosts` contains two lines for the same IP address like
```
127.0.0.1       localhost
::1     localhost ip6-localhost ip6-loopback
fe00::0 ip6-localnet
ff00::0 ip6-mcastprefix
ff02::1 ip6-allnodes
ff02::2 ip6-allrouters
ff02::3 ip6-allhosts
10.1.0.212      runnervmrd89b.dtyrjvhj1jdubpegzc4liecpve.ex.internal.cloudapp.net runnervmrd89b
169.254.1.2     host.containers.internal host.docker.internal
10.1.0.212      ipa.example.test freeipa-server-container-almalinux-10
```
and `getent hosts 10.1.0.212` returns only the first one.

https://blog.podman.io/2024/03/podman-5-0-breaking-changes-in-detail/

Resolves https://github.com/freeipa/freeipa-container/issues/734.