### PR TITLE
Workaround https://bugzilla.redhat.com/show_bug.cgi?id=1941142 on RHEL images.

### DIFF
--- a/Dockerfile.rhel-10
+++ b/Dockerfile.rhel-10
@@ -1,6 +1,9 @@
 # Build on top of the RHEL 10 image
 FROM registry.access.redhat.com/ubi10/ubi-init
 
+# Workaround https://bugzilla.redhat.com/show_bug.cgi?id=1941142
+COPY resolv.conf hostname /etc/
+
 RUN groupadd -g 288 kdcproxy ; useradd -u 288 -g 288 -c 'IPA KDC Proxy User' -r -d / -s '/sbin/nologin' kdcproxy
 RUN groupadd -g 289 ipaapi; useradd -u 289 -g 289 -c 'IPA Framework User' -r -d / -s '/sbin/nologin' ipaapi
 RUN groupadd -g 285 sssd; useradd -u 285 -g 285 -c 'User for sssd' -r -d /run/sssd/ -s '/sbin/nologin' sssd

--- a/Dockerfile.rhel-8
+++ b/Dockerfile.rhel-8
@@ -1,6 +1,9 @@
 # Build on top of the RHEL 8 image
 FROM registry.access.redhat.com/ubi8-init
 
+# Workaround https://bugzilla.redhat.com/show_bug.cgi?id=1941142
+COPY resolv.conf hostname /etc/
+
 RUN groupadd -g 288 kdcproxy ; useradd -u 288 -g 288 -c 'IPA KDC Proxy User' -d / -s '/sbin/nologin' kdcproxy
 RUN groupadd -g 289 ipaapi; useradd -u 289 -g 289 -c 'IPA Framework User' -r -d / -s '/sbin/nologin' ipaapi
 RUN groupadd -g 285 sssd; useradd -u 285 -g 285 -c 'User for sssd' -r -d /run/sssd/ -s '/sbin/nologin' sssd

--- a/Dockerfile.rhel-9
+++ b/Dockerfile.rhel-9
@@ -1,6 +1,9 @@
 # Build on top of the RHEL 9 image
 FROM registry.access.redhat.com/ubi9-init
 
+# Workaround https://bugzilla.redhat.com/show_bug.cgi?id=1941142
+COPY resolv.conf hostname /etc/
+
 RUN groupadd -g 288 kdcproxy ; useradd -u 288 -g 288 -c 'IPA KDC Proxy User' -r -d / -s '/sbin/nologin' kdcproxy
 RUN groupadd -g 289 ipaapi; useradd -u 289 -g 289 -c 'IPA Framework User' -r -d / -s '/sbin/nologin' ipaapi
 RUN groupadd -g 285 sssd; useradd -u 285 -g 285 -c 'User for sssd' -r -d /run/sssd/ -s '/sbin/nologin' sssd


### PR DESCRIPTION
We already had the fix / workaround in all other Dockerfiles where the base image does not have `/etc/resolv.conf` and `/etc/hostname`. Adding it to RHEL images now.

Resolves https://github.com/freeipa/freeipa-container/issues/735.