### PR TITLE
Complain (permissive) AppArmor seems needed for RHEL 8 and derived containers with podman on Ubuntu 26.04.

### DIFF
--- a/.github/workflows/run-partial-tests.yaml
+++ b/.github/workflows/run-partial-tests.yaml
@@ -34,6 +34,7 @@ jobs:
     if: github.event_name != 'schedule' || github.repository == 'freeipa/freeipa-container'
     outputs:
       matrix: ${{ steps.dispatch-matrix.outputs.matrix }}${{ steps.default-matrix.outputs.matrix }}
+      runs-on: ${{ steps.get-runs-on.outputs.runs-on }}
     steps:
       - id: default-matrix
         run: |
@@ -53,9 +54,14 @@ jobs:
         run: |
           echo "matrix={'os': [ '${{ inputs.os }}' ], 'docker': [ '${{ inputs.docker }}' ]}" | tee -a $GITHUB_OUTPUT
         if: github.event_name == 'workflow_dispatch' && ! inputs.full
+      - id: get-runs-on
+        run: |
+          RUNS_ON='${{ inputs.runs-on }}'
+          RUNS_ON=${RUNS_ON:-ubuntu-24.04}
+          echo "runs-on=$RUNS_ON" | tee -a $GITHUB_OUTPUT
 
   test:
-    runs-on: ${{ inputs.runs-on || 'ubuntu-24.04' }}
+    runs-on: ${{ needs.gen-matrix.outputs.runs-on }}
     needs: [ gen-matrix ]
     strategy:
       fail-fast: false
@@ -68,6 +74,8 @@ jobs:
         if: matrix.docker == 'docker'
       - run: mkdir -p ~/.config/containers && cp ci/containers-podman-5.conf ~/.config/containers/containers.conf
         if: matrix.docker == 'podman'
+      - run: sudo apt update && sudo apt install -y apparmor-utils && sudo aa-complain --profile hostname smbd
+        if: startsWith(needs.gen-matrix.outputs.runs-on, 'ubuntu-26.04') && matrix.docker == 'podman' && endsWith(matrix.os, '-8')
       - name: For RHEL builds, use entitlements
         if: ${{ startsWith(matrix.os, 'rhel-') }}
         uses: ./.github/actions/podman-entitlement


### PR DESCRIPTION
Addressing
```
  [1/29]: configuring certificate server instance
Failed to configure CA instance
See the installation logs and the following files/directories for more information:
  /var/log/pki/pki-tomcat
  [error] RuntimeError: CA configuration failed.
CA configuration failed.
```
and
```
apparmor="DENIED" operation="open" class="file" profile="hostname" name="/data/etc/authselect/nsswitch.conf" pid=18694 comm="dnsdomainname" requested_mask="r" denied_mask="r" fsuid=1000 ouid=1000
```
and
```
Jun 12 06:40:27 ipa.example.test systemd[1]: Starting Samba SMB Daemon...
Jun 12 06:40:27 ipa.example.test smbd[5087]: [2026/06/12 06:40:27,  0] ../../lib/util/debug.c:1274(reopen_one_log)
Jun 12 06:40:27 ipa.example.test smbd[5087]:   reopen_one_log: Unable to open new log file '/var/log/samba/log.smbd': Permission denied
Jun 12 06:40:27 ipa.example.test smbd[5087]: Can't load /etc/samba/smb.conf - run testparm to debug it
Jun 12 06:40:27 ipa.example.test smbd[5087]: smbd - Failed to load config file!
Jun 12 06:40:27 ipa.example.test systemd[1]: smb.service: Main process exited, code=exited, status=1/FAILURE
```
and
```
apparmor="DENIED" operation="mknod" class="file" profile="smbd" name="/data/var/log/samba/log.smbd" pid=27017 comm="smbd" requested_mask="c" denied_mask="c" fsuid=1000 ouid=1000 apparmor="DENIED" operation="open" class="file" profile="smbd" name="/data/etc/samba/smb.conf" pid=27627 comm="smbd" requested_mask="r" denied_mask="r" fsuid=1000 ouid=1000
```

Resolves https://github.com/freeipa/freeipa-container/issues/740.