### PR TITLE
Add tests on Ubuntu 26.04, except for Kubernetes with CRI-O and containerd.

### DIFF
--- a/.github/build-test-params.yaml
+++ b/.github/build-test-params.yaml
@@ -2,6 +2,7 @@
 run:
   runs-on:
     ubuntu-24.04: 1
+    ubuntu-26.04: 1
   runtime:
     podman: 4
     sudo podman: 1
@@ -22,6 +23,7 @@ run:
 test-upgrade:
   runs-on:
     ubuntu-24.04: 1
+    ubuntu-26.04: 1
   runtime:
     podman: 2
     docker rootless: 2
@@ -65,6 +67,7 @@ test-upgrade:
 k8s:
   runs-on:
     ubuntu-24.04: 1
+    ubuntu-26.04: 1
   kubernetes:
     k3s: 1
     kubeadm init: 1
@@ -82,6 +85,10 @@ k8s:
       runtime: docker
     - kubernetes: k0s
       runtime: docker
+    - runs-on: ubuntu-26.04
+      runtime: cri-o
+    - runs-on: ubuntu-26.04
+      runtime: containerd
 
 push:
   exclude:

--- a/.github/workflows/run-partial-tests.yaml
+++ b/.github/workflows/run-partial-tests.yaml
@@ -24,6 +24,8 @@ on:
         description: Host Ubuntu version
         type: choice
         options:
+          - ubuntu-26.04
+          - ubuntu-26.04-arm
           - ubuntu-24.04
           - ubuntu-24.04-arm
 
@@ -57,7 +59,7 @@ jobs:
       - id: get-runs-on
         run: |
           RUNS_ON='${{ inputs.runs-on }}'
-          RUNS_ON=${RUNS_ON:-ubuntu-24.04}
+          RUNS_ON=${RUNS_ON:-ubuntu-26.04}
           echo "runs-on=$RUNS_ON" | tee -a $GITHUB_OUTPUT
 
   test:

--- a/.github/workflows/test-rhel.yaml
+++ b/.github/workflows/test-rhel.yaml
@@ -23,7 +23,7 @@ jobs:
 
   build-test-rhel-podman:
     name: Build and test RHEL image
-    runs-on: ubuntu-24.04-arm
+    runs-on: ubuntu-26.04-arm
     needs: [ test-subscription ]
     if: needs.test-subscription.outputs.has_rhel_subscriptions == 1
     strategy:

--- a/ci/test-matrix-to-html.jq
+++ b/ci/test-matrix-to-html.jq
@@ -96,9 +96,9 @@ end,
 "  <thead>",
 "    <tr>",
 	(
-	if $ARGS.named["job"] == "run" then [ "Runtime", "Readonly", "External CA", "Volume" ]
-	elif $ARGS.named["job"] == "test-upgrade" then [ "Runtime", "Volume", "Upgrade from" ]
-	elif $ARGS.named["job"] == "k8s" then [ "Kubernetes", "Runtime" ]
+	if $ARGS.named["job"] == "run" then [ "Host Ubuntu", "Runtime", "Readonly", "External CA", "Volume" ]
+	elif $ARGS.named["job"] == "test-upgrade" then [ "Host Ubuntu", "Runtime", "Volume", "Upgrade from" ]
+	elif $ARGS.named["job"] == "k8s" then [ "Host Ubuntu", "Kubernetes", "Runtime" ]
 	else empty end
 	| th(3; 1)
 	),
@@ -117,11 +117,11 @@ end,
 | [ .[] | .status = if .nopush then "nopush" else if .["fresh-image"] then "fresh-image" else false end end ]
 | reduce .[] as $row ({};
 	if $ARGS.named["job"] == "run"
-	then .[ $row.runtime ][ $row.readonly ][ $row.ca ][ $row.volume ][ $row.os ][ $row.arch ] = $row.status
+	then .[ $row["runs-on"] ][ $row.runtime ][ $row.readonly ][ $row.ca ][ $row.volume ][ $row.os ][ $row.arch ] = $row.status
 	elif $ARGS.named["job"] == "test-upgrade"
-	then .[ $row.runtime ][ $row.volume ][ $row[ "data-from" ] ][ $row.os ][ $row.arch ] = $row.status
+	then .[ $row["runs-on"] ][ $row.runtime ][ $row.volume ][ $row[ "data-from" ] ][ $row.os ][ $row.arch ] = $row.status
 	elif $ARGS.named["job"] == "k8s"
-	then .[ $row.kubernetes ][ $row.runtime ][ $row.os ][ $row.arch ] = $row.status
+	then .[ $row["runs-on"] ][ $row.kubernetes ][ $row.runtime ][ $row.os ][ $row.arch ] = $row.status
 	end
 )
 | walk(if type == "object"


### PR DESCRIPTION
This implements https://github.com/freeipa/freeipa-container/issues/727, except for the Kubernetes on Ubuntu 26.04 with containerd and CRI-O issues tracked in
* https://github.com/freeipa/freeipa-container/issues/736
* https://github.com/freeipa/freeipa-container/issues/737