### PR TITLE
Workaround https://github.com/freeipa/freeipa-container/issues/750 and https://github.com/cri-o/cri-o/issues/9865

### DIFF
--- a/.github/actions/install-crio/action.yaml
+++ b/.github/actions/install-crio/action.yaml
@@ -18,5 +18,12 @@ runs:
         # for images like rancher/local-path-provisioner:v0.0.31 
         # due to multiple unqualified-search-registries entries in /etc/containers/registries.conf.d/crio.conf
         echo 'unqualified-search-registries = ["docker.io"]' | sudo tee /etc/containers/registries.conf.d/no-unqualified-quay.conf
+
+        # Workaround https://github.com/cri-o/cri-o/issues/9865 / https://github.com/freeipa/freeipa-container/issues/750
+        if [ -f /etc/containers/storage.conf ] ; then
+            sudo mv -f /etc/containers/storage.conf /etc/containers/storage.conf.dist
+            sudo sudo podman system reset -f
+        fi
+
         sudo systemctl start crio.service
       shell: bash -euxo pipefail {0}

--- a/.github/build-test-params.yaml
+++ b/.github/build-test-params.yaml
@@ -89,8 +89,6 @@ k8s:
       runtime: cri-o
     - runs-on: ubuntu-26.04
       runtime: containerd
-    - runs-on: ubuntu-24.04
-      runtime: cri-o
 
 push:
   exclude:


### PR DESCRIPTION
We want to avoid using `fuse-overlayfs` which the new ubuntu 24.04 GitHub runner images introduced and which causes `nobody` to own root directory which in turn upsets `systemd-tmpfiles`.

Resolves https://github.com/freeipa/freeipa-container/issues/750.